### PR TITLE
Circuit breaker action log && fallback on failure strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to `knotx-fragments` will be documented in this file.
 List of changes that are finished but not yet released in any final version.
 
 ## Version 2.1.0
-- [PR-62](https://github.com/Knotx/knotx-fragments/pull/62) - 
+- [PR-62](https://github.com/Knotx/knotx-fragments/pull/62) - It introduces task & graph node factories. It is connected with issue #49.
 - [PR-51](https://github.com/Knotx/knotx-fragments/pull/51) - Introduces extendable task definition allowing to define different node types and custom task providers. Marks the `actions` task configuration entry as deprecated, introduces `subtasks` instread.
 - [PR-56](https://github.com/Knotx/knotx-fragments/pull/56) - Makes composite node identifiers changeable. Renames `ActionNode` to `SingleNode`. 
 - [PR-55](https://github.com/Knotx/knotx-fragments/pull/55) - Action log mechanism implementation. Renames `ActionFatalException` to `NodeFatalException`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to `knotx-fragments` will be documented in this file.
 
 ## Unreleased
 List of changes that are finished but not yet released in any final version.
+
+## Version 2.1.0
 - [PR-62](https://github.com/Knotx/knotx-fragments/pull/62) - 
 - [PR-51](https://github.com/Knotx/knotx-fragments/pull/51) - Introduces extendable task definition allowing to define different node types and custom task providers. Marks the `actions` task configuration entry as deprecated, introduces `subtasks` instread.
 - [PR-56](https://github.com/Knotx/knotx-fragments/pull/56) - Makes composite node identifiers changeable. Renames `ActionNode` to `SingleNode`. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to `knotx-fragments` will be documented in this file.
 
 ## Unreleased
 List of changes that are finished but not yet released in any final version.
+- [PR-60](https://github.com/Knotx/knotx-fragments/pull/60) - Adding node log to circuit breaker action. Enforce fallback on error.
 
 ## Version 2.1.0
 - [PR-62](https://github.com/Knotx/knotx-fragments/pull/62) - It introduces task & graph node factories. It is connected with issue #49.

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -71,8 +71,8 @@ steps:
       tasks: 'build-docker'
     displayName: "Build Starter Kit: Docker"
   - script: |
-      if [[ -f "$(workspaceDir)/$project/gradlew" ]]; then
-        REPO=$(cut -d'/' -f2 <<<$(Build.Repository.Name))
+      REPO=$(cut -d'/' -f2 <<<$(Build.Repository.Name))
+      if [[ -f "$(workspaceDir)/$REPO/gradlew" ]]; then
         $(workspaceDir)/$REPO/gradlew -p $(workspaceDir)/$REPO clean test jacocoTestReport
         bash <(curl -s https://codecov.io/bash) -s $(workspaceDir)/$REPO -t $(CODECOV_TOKEN)
       fi

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 trigger:
   - master
 
@@ -21,7 +20,6 @@ pool:
 
 variables:
   workspaceDir: knotx-repos
-  targetRepository: knotx-fragments
 
 steps:
   - script: |
@@ -38,6 +36,11 @@ steps:
           ./pull-all.sh -r ../../$(workspaceDir) -b $(System.PullRequest.SourceBranch) -a
         fi
     displayName: "Clone all repositories"
+  - task: Maven@3
+    inputs:
+      mavenPomFile: '$(workspaceDir)/knotx-dependencies/pom.xml'
+      goals: 'install'
+    displayName: "Build Dependencies"
   - task: Gradle@2
     inputs:
       gradleWrapperFile: '$(workspaceDir)/knotx-stack/gradlew'
@@ -68,6 +71,9 @@ steps:
       tasks: 'build-docker'
     displayName: "Build Starter Kit: Docker"
   - script: |
-      $(workspaceDir)/$(targetRepository)/gradlew -p $(workspaceDir)/$(targetRepository) clean test jacocoTestReport
-      bash <(curl -s https://codecov.io/bash) -s $(workspaceDir)/$(targetRepository) -t $(CODECOV_TOKEN)
+      if [[ -f "$(workspaceDir)/$project/gradlew" ]]; then
+        REPO=$(cut -d'/' -f2 <<<$(Build.Repository.Name))
+        $(workspaceDir)/$REPO/gradlew -p $(workspaceDir)/$REPO clean test jacocoTestReport
+        bash <(curl -s https://codecov.io/bash) -s $(workspaceDir)/$REPO -t $(CODECOV_TOKEN)
+      fi
     displayName: "Run Codecov inspection"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,7 +18,7 @@ import org.gradle.kotlin.dsl.apply
 
 plugins {
     java
-    id("io.knotx.publish-all-composite") version "0.1.3"
+    id("io.knotx.publish-all-composite") version "0.1.4"
 }
 
 subprojects {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version=2.1.0
+version=2.1.1-SNAPSHOT
 publication.scm=scm:git:git://github.com/Knotx/knotx-fragments.git

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version=2.0.1-SNAPSHOT
+version=2.1.0
 publication.scm=scm:git:git://github.com/Knotx/knotx-fragments.git

--- a/handler/README.md
+++ b/handler/README.md
@@ -454,6 +454,25 @@ doAction = product
 The `doAction` attribute specifies a wrapped simple action by its name. When `doAction` throws an error 
 or times out then the custom `fallback` transition is returned.
 
+##### Circuit Breaker Action Log
+
+Behavior logs the following data
+
+ - `invocationCount` - number of retries
+ - `fallback` - in case fallback defined entry will contain message from exception which causes error
+
+CB log includes logs produces by wrapped action. 
+Please note that not every call can be visible in `doAction` entry.  
+
+
+| Action call ends  | duration  | Wrapped action log  | 
+| :---------: |:---------:|:---------|
+| transition [ `_success`]  |  yes | Available        |
+| transition [ `_error`] |  yes |  Available        |
+| TIMEOUT                 |  no |  Not available        |
+| Failure  |  yes |   Not available        |
+| Exception  |  |  no |  Not available        |
+
 ### In-memory Cache Behaviour
 It wraps a simple action with cache. It caches a payload values added by a `doAction` action and 
 puts cached values in next invocations. It uses in-memory Guava cache implementation. The 

--- a/handler/README.md
+++ b/handler/README.md
@@ -451,10 +451,10 @@ config {
 }
 doAction = product
 ```
-The `doAction` attribute specifies a wrapped simple action by its name. When `doAction` throws an error 
-or times out then the custom `fallback` transition is returned.
+The `doAction` attribute specifies a wrapped simple action by its name. When `doAction` throws an 
+error or times out then the custom `fallback` transition is returned.
 
-##### Circuit Breaker Action Log
+#### Circuit Breaker Action Log
 
 Circuit Breaker logs the following data
 
@@ -464,7 +464,8 @@ Circuit Breaker logs the following data
     - `doAction` ends with `_error` transition,
     - CB times out `doAction` invocation.
 
-Circuit Breaker log includes logs produced by the [`doAction`](#circuit-breaker-behaviour). Each `invocation log` has entries:
+Circuit Breaker log includes logs produced by the [`doAction`](#circuit-breaker-behaviour). Each 
+`invocation log` has entries:
 
  - `duration` - how long takes execution of action - in milisecond
  - `succuess` - execution ends up with success - ()
@@ -480,6 +481,12 @@ Please note that not every call can be visible in `invocation log` entry.
 | TIMEOUT                |  No  |
 | Failure                |  No  |
 | Exception              |  No  |
+
+TIMEOUT - `doAction` does not end withing the required time (`circuitBreakerOptions.timeout`), 
+please note that `doAction` is not interrupted by a circuit breaker
+Failure - `doAction` fails, means that `doAction` calls `failed` method on result handler
+Exception - `doAction` throws an exception
+
 
 ### In-memory Cache Behaviour
 It wraps a simple action with cache. It caches a payload values added by a `doAction` action and 

--- a/handler/README.md
+++ b/handler/README.md
@@ -470,7 +470,11 @@ Circuit Breaker log includes logs produces by wrapped action. Each  `invocation 
 Please note that not every call can be visible in `invocation log` entry.  
 
 
-| Action call ends  | invocation log  | Wrapped action log  | 
+| Result                           | Invocation log  |
+| :--------------------: |:-----|
+| transition: `_success` |  Yes |
+| transition: `_error`       |  Yes |
+| TIMEOUT                      |  No  |
 | :---------: |:---------:|:---------|
 | transition [ `_success`]  |  Available | Available        |
 | transition [ `_error`] |  Available |  Available        |

--- a/handler/README.md
+++ b/handler/README.md
@@ -456,22 +456,27 @@ or times out then the custom `fallback` transition is returned.
 
 ##### Circuit Breaker Action Log
 
-Behavior logs the following data
+Circuit Breaker logs the following data
 
  - `invocationCount` - number of retries
  - `fallback` - in case fallback defined entry will contain message from exception which causes error
 
-CB log includes logs produces by wrapped action. 
-Please note that not every call can be visible in `doAction` entry.  
+Circuit Breaker log includes logs produces by wrapped action. Each  `invocation log` has entries:
+
+ - `duration` - how long takes execution of action - in milisecond
+ - `succuess` - execution ends up with success - ()
+ - `actionLog` - Wrapped action log
+ 
+Please note that not every call can be visible in `invocation log` entry.  
 
 
-| Action call ends  | duration  | Wrapped action log  | 
+| Action call ends  | invocation log  | Wrapped action log  | 
 | :---------: |:---------:|:---------|
-| transition [ `_success`]  |  yes | Available        |
-| transition [ `_error`] |  yes |  Available        |
-| TIMEOUT                 |  no |  Not available        |
-| Failure  |  yes |   Not available        |
-| Exception  |  |  no |  Not available        |
+| transition [ `_success`]  |  Available | Available        |
+| transition [ `_error`] |  Available |  Available        |
+| TIMEOUT                 |  Not available |  Not available        |
+| Failure                 |  Available |   Not available        |
+| Exception  |   Not available |  Not available        |
 
 ### In-memory Cache Behaviour
 It wraps a simple action with cache. It caches a payload values added by a `doAction` action and 

--- a/handler/README.md
+++ b/handler/README.md
@@ -454,6 +454,22 @@ doAction = product
 The `doAction` attribute specifies a wrapped simple action by its name. When `doAction` throws an 
 error or times out then the custom `fallback` transition is returned.
 
+| Invocation            | Retry                  | Result (Transition, Log) |
+| :-------------------: |:----------------------:|:-------------------------|
+| transition: `_success`| -                      |  `_success`, [s]         |
+| transition: `_error`  | transition: `_success` | `_success`, [e,s]        |
+| Failure               | transition: `_success` | `_success`, [e,s]        |
+| Failure               | transition: `_error`   | `_fallback`, [e,e]       |
+| Failure               | TIMEOUT                |  `_fallback`, [e,t]      |
+| TIMEOUT               | Failure                |  `_fallback`, [t,e]      |
+| TIMEOUT               | TIMEOUT                | `_fallback`, [t,t]       |
+
+Labels:
+- TIMEOUT - `doAction` does not end withing the required time (`circuitBreakerOptions.timeout`), 
+- please note that `doAction` is not interrupted by a circuit breaker
+- Failure - `doAction` fails, means that `doAction` calls `failed` method on result handler
+- Exception - `doAction` throws an exception
+
 #### Circuit Breaker Action Log
 
 Circuit Breaker logs the following data
@@ -481,12 +497,6 @@ Please note that not every call can be visible in `invocation log` entry.
 | TIMEOUT                |  No  |
 | Failure                |  No  |
 | Exception              |  No  |
-
-TIMEOUT - `doAction` does not end withing the required time (`circuitBreakerOptions.timeout`), 
-please note that `doAction` is not interrupted by a circuit breaker
-Failure - `doAction` fails, means that `doAction` calls `failed` method on result handler
-Exception - `doAction` throws an exception
-
 
 ### In-memory Cache Behaviour
 It wraps a simple action with cache. It caches a payload values added by a `doAction` action and 

--- a/handler/README.md
+++ b/handler/README.md
@@ -452,9 +452,9 @@ config {
 doAction = product
 ```
 The `doAction` attribute specifies a wrapped simple action by its name. When `doAction` throws an 
-error or times out then the custom `fallback` transition is returned.
+error or times out then the custom `_fallback` transition is returned.
 
-| Invocation            | Retry                  | Result (Transition, Log) |
+| #1 `doAction` result  | Retry `doAction` result | CB result (Transition, Log)  |
 | :-------------------: |:----------------------:|:-------------------------|
 | transition: `_success`| -                      |  `_success`, [s]         |
 | transition: `_error`  | transition: `_success` | `_success`, [e,s]        |
@@ -469,6 +469,7 @@ Labels:
 - please note that `doAction` is not interrupted by a circuit breaker
 - Failure - `doAction` fails, means that `doAction` calls `failed` method on result handler
 - Exception - `doAction` throws an exception
+- `s` - success, `e` - error, `t` - timeout
 
 #### Circuit Breaker Action Log
 

--- a/handler/README.md
+++ b/handler/README.md
@@ -461,7 +461,7 @@ Circuit Breaker logs the following data
  - `invocationCount` - number of retries
  - `fallback` - in case fallback defined entry will contain message from exception which causes error
 
-Circuit Breaker log includes logs produces by wrapped action. Each  `invocation log` has entries:
+Circuit Breaker log includes logs produced by the [`doAction`](#circuit-breaker-behaviour). Each `invocation log` has entries:
 
  - `duration` - how long takes execution of action - in milisecond
  - `succuess` - execution ends up with success - ()

--- a/handler/README.md
+++ b/handler/README.md
@@ -459,7 +459,10 @@ or times out then the custom `fallback` transition is returned.
 Circuit Breaker logs the following data
 
  - `invocationCount` - number of retries
- - `fallback` - in case fallback defined entry will contain message from exception which causes error
+ - `error` - contains exception details when: 
+    - `doAction` fails, 
+    - `doAction` ends with `_error` transition,
+    - CB times out `doAction` invocation.
 
 Circuit Breaker log includes logs produced by the [`doAction`](#circuit-breaker-behaviour). Each `invocation log` has entries:
 

--- a/handler/README.md
+++ b/handler/README.md
@@ -470,17 +470,13 @@ Circuit Breaker log includes logs produced by the [`doAction`](#circuit-breaker-
 Please note that not every call can be visible in `invocation log` entry.  
 
 
-| Result                           | Invocation log  |
+| Result                 | Invocation log  |
 | :--------------------: |:-----|
 | transition: `_success` |  Yes |
-| transition: `_error`       |  Yes |
-| TIMEOUT                      |  No  |
-| :---------: |:---------:|:---------|
-| transition [ `_success`]  |  Available | Available        |
-| transition [ `_error`] |  Available |  Available        |
-| TIMEOUT                 |  Not available |  Not available        |
-| Failure                 |  Available |   Not available        |
-| Exception  |   Not available |  Not available        |
+| transition: `_error`   |  Yes |
+| TIMEOUT                |  No  |
+| Failure                |  No  |
+| Exception              |  No  |
 
 ### In-memory Cache Behaviour
 It wraps a simple action with cache. It caches a payload values added by a `doAction` action and 

--- a/handler/api/build.gradle.kts
+++ b/handler/api/build.gradle.kts
@@ -21,6 +21,7 @@ plugins {
     id("io.knotx.codegen")
     id("io.knotx.maven-publish")
     id("io.knotx.jacoco")
+    id("io.knotx.unit-test")
     id("org.nosphere.apache.rat") version "0.4.0"
 }
 

--- a/handler/api/docs/asciidoc/dataobjects.adoc
+++ b/handler/api/docs/asciidoc/dataobjects.adoc
@@ -1,18 +1,5 @@
 = Cheatsheets
 
-[[ActionLog]]
-== ActionLog
-
-
-[cols=">25%,25%,50%"]
-[frame="topbot"]
-|===
-^|Name | Type ^| Description
-|[[alias]]`@alias`|`String`|-
-|[[doActionLogs]]`@doActionLogs`|`Array of link:dataobjects.html#ActionLog[ActionLog]`|-
-|[[logs]]`@logs`|`Json object`|-
-|===
-
 [[ActionPayload]]
 == ActionPayload
 

--- a/handler/api/src/main/java/io/knotx/fragments/handler/api/actionlog/ActionInvocationLog.java
+++ b/handler/api/src/main/java/io/knotx/fragments/handler/api/actionlog/ActionInvocationLog.java
@@ -15,6 +15,7 @@
  */
 package io.knotx.fragments.handler.api.actionlog;
 
+import java.util.Objects;
 import java.util.Optional;
 
 import io.vertx.core.json.JsonObject;
@@ -60,6 +61,34 @@ public class ActionInvocationLog {
     return new JsonObject().put("duration", duration)
         .put("success", success)
         .put("doActionLog", toDoActionLogJson());
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    ActionInvocationLog that = (ActionInvocationLog) o;
+    return success == that.success &&
+        Objects.equals(duration, that.duration) &&
+        Objects.equals(doActionLog, that.doActionLog);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(duration, success, doActionLog);
+  }
+
+  @Override
+  public String toString() {
+    return "ActionInvocationLog{" +
+        "duration=" + duration +
+        ", success=" + success +
+        ", doActionLog=" + doActionLog +
+        '}';
   }
 
   private JsonObject toDoActionLogJson() {

--- a/handler/api/src/main/java/io/knotx/fragments/handler/api/actionlog/ActionInvocationLog.java
+++ b/handler/api/src/main/java/io/knotx/fragments/handler/api/actionlog/ActionInvocationLog.java
@@ -38,6 +38,14 @@ public class ActionInvocationLog {
     this.doActionLog = toDoActionLog(json);
   }
 
+  static ActionInvocationLog success(long duration, ActionLog actionLog) {
+    return new ActionInvocationLog(duration, true, actionLog);
+  }
+
+  static ActionInvocationLog error(long duration,  ActionLog actionLog) {
+    return new ActionInvocationLog(duration, false, actionLog);
+  }
+
   private ActionLog toDoActionLog(JsonObject json) {
     return Optional.ofNullable(json)
         .map(j -> j.getJsonObject("doActionLog"))
@@ -93,13 +101,5 @@ public class ActionInvocationLog {
 
   private JsonObject toDoActionLogJson() {
     return Optional.ofNullable(doActionLog).map(ActionLog::toJson).orElse(null);
-  }
-
-  static ActionInvocationLog success(long duration, ActionLog actionLog) {
-    return new ActionInvocationLog(duration, true, actionLog);
-  }
-
-  static ActionInvocationLog error(long duration,  ActionLog actionLog) {
-    return new ActionInvocationLog(duration, false, actionLog);
   }
 }

--- a/handler/api/src/main/java/io/knotx/fragments/handler/api/actionlog/ActionInvocationLog.java
+++ b/handler/api/src/main/java/io/knotx/fragments/handler/api/actionlog/ActionInvocationLog.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2019 Knot.x Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.knotx.fragments.handler.api.actionlog;
+
+import java.util.Optional;
+
+import io.vertx.core.json.JsonObject;
+
+public class ActionInvocationLog {
+
+  private final Long duration;
+  private final boolean success;
+  private final ActionLog doActionLog;
+
+  private ActionInvocationLog(long duration, boolean success, ActionLog doActionLog) {
+    this.duration = duration;
+    this.success = success;
+    this.doActionLog = doActionLog;
+  }
+
+  ActionInvocationLog(JsonObject json) {
+    this.duration = json.getLong("duration");
+    this.success = json.getBoolean("success");
+    this.doActionLog = toDoActionLog(json);
+  }
+
+  private ActionLog toDoActionLog(JsonObject json) {
+    return Optional.ofNullable(json)
+        .map(j -> j.getJsonObject("doActionLog"))
+        .map(ActionLog::new)
+        .orElse(null);
+  }
+
+  public Long getDuration() {
+    return duration;
+  }
+
+  public boolean isSuccess() {
+    return success;
+  }
+
+  public ActionLog getDoActionLog() {
+    return doActionLog;
+  }
+
+  public JsonObject toJson() {
+    return new JsonObject().put("duration", duration)
+        .put("success", success)
+        .put("doActionLog", toDoActionLogJson());
+  }
+
+  private JsonObject toDoActionLogJson() {
+    return Optional.ofNullable(doActionLog).map(ActionLog::toJson).orElse(null);
+  }
+
+  static ActionInvocationLog success(long duration, ActionLog actionLog) {
+    return new ActionInvocationLog(duration, true, actionLog);
+  }
+
+  static ActionInvocationLog error(long duration,  ActionLog actionLog) {
+    return new ActionInvocationLog(duration, false, actionLog);
+  }
+}

--- a/handler/api/src/main/java/io/knotx/fragments/handler/api/actionlog/ActionInvocationLog.java
+++ b/handler/api/src/main/java/io/knotx/fragments/handler/api/actionlog/ActionInvocationLog.java
@@ -46,7 +46,7 @@ public class ActionInvocationLog {
     return new ActionInvocationLog(duration, true, actionLog);
   }
 
-  static ActionInvocationLog error(long duration,  ActionLog actionLog) {
+  static ActionInvocationLog error(long duration, ActionLog actionLog) {
     return new ActionInvocationLog(duration, false, actionLog);
   }
 
@@ -65,7 +65,7 @@ public class ActionInvocationLog {
   public JsonObject toJson() {
     return new JsonObject().put("duration", duration)
         .put("success", success)
-        .put("doActionLog", toDoActionLogJson());
+        .put("doActionLog", doActionLog != null ? doActionLog.toJson() : null);
   }
 
   @Override
@@ -101,9 +101,5 @@ public class ActionInvocationLog {
         .map(j -> j.getJsonObject(DO_ACTION_LOG))
         .map(ActionLog::new)
         .orElse(null);
-  }
-
-  private JsonObject toDoActionLogJson() {
-    return Optional.ofNullable(doActionLog).map(ActionLog::toJson).orElse(null);
   }
 }

--- a/handler/api/src/main/java/io/knotx/fragments/handler/api/actionlog/ActionInvocationLog.java
+++ b/handler/api/src/main/java/io/knotx/fragments/handler/api/actionlog/ActionInvocationLog.java
@@ -22,6 +22,10 @@ import io.vertx.core.json.JsonObject;
 
 public class ActionInvocationLog {
 
+  static final String DURATION = "duration";
+  static final String SUCCESS = "success";
+  static final String DO_ACTION_LOG = "doActionLog";
+
   private final Long duration;
   private final boolean success;
   private final ActionLog doActionLog;
@@ -33,8 +37,8 @@ public class ActionInvocationLog {
   }
 
   ActionInvocationLog(JsonObject json) {
-    this.duration = json.getLong("duration");
-    this.success = json.getBoolean("success");
+    this.duration = json.getLong(DURATION);
+    this.success = json.getBoolean(SUCCESS);
     this.doActionLog = toDoActionLog(json);
   }
 
@@ -44,13 +48,6 @@ public class ActionInvocationLog {
 
   static ActionInvocationLog error(long duration,  ActionLog actionLog) {
     return new ActionInvocationLog(duration, false, actionLog);
-  }
-
-  private ActionLog toDoActionLog(JsonObject json) {
-    return Optional.ofNullable(json)
-        .map(j -> j.getJsonObject("doActionLog"))
-        .map(ActionLog::new)
-        .orElse(null);
   }
 
   public Long getDuration() {
@@ -97,6 +94,13 @@ public class ActionInvocationLog {
         ", success=" + success +
         ", doActionLog=" + doActionLog +
         '}';
+  }
+
+  private ActionLog toDoActionLog(JsonObject json) {
+    return Optional.ofNullable(json)
+        .map(j -> j.getJsonObject(DO_ACTION_LOG))
+        .map(ActionLog::new)
+        .orElse(null);
   }
 
   private JsonObject toDoActionLogJson() {

--- a/handler/api/src/main/java/io/knotx/fragments/handler/api/actionlog/ActionLog.java
+++ b/handler/api/src/main/java/io/knotx/fragments/handler/api/actionlog/ActionLog.java
@@ -18,12 +18,10 @@ package io.knotx.fragments.handler.api.actionlog;
 import static java.util.Collections.unmodifiableList;
 import static java.util.stream.Collectors.toList;
 
-import java.util.List;
-import java.util.Objects;
-import java.util.stream.StreamSupport;
-
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
+import java.util.List;
+import java.util.stream.StreamSupport;
 
 public class ActionLog {
 
@@ -31,7 +29,7 @@ public class ActionLog {
   private final JsonObject logs;
   private final List<ActionInvocationLog> doActionLogs;
 
-  ActionLog(String alias, JsonObject logs, List<ActionInvocationLog> doActionLogs) {
+  public ActionLog(String alias, JsonObject logs, List<ActionInvocationLog> doActionLogs) {
     this.alias = alias;
     this.logs = logs;
     this.doActionLogs = doActionLogs;
@@ -44,7 +42,7 @@ public class ActionLog {
   }
 
   private List<ActionInvocationLog> toInvocationLogList(JsonObject actionLog) {
-    Iterable<Object> iterable = () -> actionLog.getJsonArray("doAction").iterator();
+    Iterable<Object> iterable = () -> actionLog.getJsonArray("doActionLogs").iterator();
     return StreamSupport.stream(iterable.spliterator(), false)
         .map(JsonObject::mapFrom)
         .map(ActionInvocationLog::new)
@@ -65,26 +63,7 @@ public class ActionLog {
 
   public JsonObject toJson() {
     return new JsonObject().put("alias", alias).put("logs", getLogs())
-        .put("doAction", toDoActionArray());
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-    ActionLog actionLog = (ActionLog) o;
-    return alias.equals(actionLog.alias) &&
-        logs.equals(actionLog.logs) &&
-        Objects.equals(doActionLogs, actionLog.doActionLogs);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(alias, logs, doActionLogs);
+        .put("doActionLogs", toDoActionArray());
   }
 
   @Override

--- a/handler/api/src/main/java/io/knotx/fragments/handler/api/actionlog/ActionLog.java
+++ b/handler/api/src/main/java/io/knotx/fragments/handler/api/actionlog/ActionLog.java
@@ -59,7 +59,7 @@ public class ActionLog {
     return logs.copy();
   }
 
-  public List<ActionInvocationLog> getDoActionLogs() {
+  public List<ActionInvocationLog> getInvocationLogs() {
     return unmodifiableList(doActionLogs);
   }
 
@@ -97,7 +97,7 @@ public class ActionLog {
   }
 
   private JsonArray toDoActionArray() {
-    return getDoActionLogs().stream()
+    return getInvocationLogs().stream()
         .map(ActionInvocationLog::toJson)
         .collect(JsonArray::new,
             JsonArray::add,

--- a/handler/api/src/main/java/io/knotx/fragments/handler/api/actionlog/ActionLog.java
+++ b/handler/api/src/main/java/io/knotx/fragments/handler/api/actionlog/ActionLog.java
@@ -40,10 +40,10 @@ public class ActionLog {
   public ActionLog(JsonObject actionLog) {
     this.alias = actionLog.getString("alias");
     this.logs = actionLog.getJsonObject("logs");
-    this.doActionLogs = toDoActionLogs(actionLog);
+    this.doActionLogs = toInvocationLogList(actionLog);
   }
 
-  private List<ActionInvocationLog> toDoActionLogs(JsonObject actionLog) {
+  private List<ActionInvocationLog> toInvocationLogList(JsonObject actionLog) {
     Iterable<Object> iterable = () -> actionLog.getJsonArray("doAction").iterator();
     return StreamSupport.stream(iterable.spliterator(), false)
         .map(JsonObject::mapFrom)

--- a/handler/api/src/main/java/io/knotx/fragments/handler/api/actionlog/ActionLog.java
+++ b/handler/api/src/main/java/io/knotx/fragments/handler/api/actionlog/ActionLog.java
@@ -22,18 +22,16 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.StreamSupport;
 
-import io.vertx.codegen.annotations.DataObject;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
-@DataObject
 public class ActionLog {
 
   private final String alias;
   private final JsonObject logs;
-  private final List<ActionLog> doActionLogs;
+  private final List<ActionInvocationLog> doActionLogs;
 
-  ActionLog(String alias, JsonObject logs, List<ActionLog> doActionLogs) {
+  ActionLog(String alias, JsonObject logs, List<ActionInvocationLog> doActionLogs) {
     this.alias = alias;
     this.logs = logs;
     this.doActionLogs = doActionLogs;
@@ -45,11 +43,11 @@ public class ActionLog {
     this.doActionLogs = toDoActionLogs(actionLog);
   }
 
-  private List<ActionLog> toDoActionLogs(JsonObject actionLog) {
+  private List<ActionInvocationLog> toDoActionLogs(JsonObject actionLog) {
     Iterable<Object> iterable = () -> actionLog.getJsonArray("doAction").iterator();
     return StreamSupport.stream(iterable.spliterator(), false)
         .map(JsonObject::mapFrom)
-        .map(ActionLog::new)
+        .map(ActionInvocationLog::new)
         .collect(toList());
   }
 
@@ -61,7 +59,7 @@ public class ActionLog {
     return logs.copy();
   }
 
-  public List<ActionLog> getDoActionLogs() {
+  public List<ActionInvocationLog> getDoActionLogs() {
     return unmodifiableList(doActionLogs);
   }
 
@@ -100,7 +98,7 @@ public class ActionLog {
 
   private JsonArray toDoActionArray() {
     return getDoActionLogs().stream()
-        .map(ActionLog::toJson)
+        .map(ActionInvocationLog::toJson)
         .collect(JsonArray::new,
             JsonArray::add,
             JsonArray::addAll);

--- a/handler/api/src/main/java/io/knotx/fragments/handler/api/actionlog/ActionLogBuilder.java
+++ b/handler/api/src/main/java/io/knotx/fragments/handler/api/actionlog/ActionLogBuilder.java
@@ -34,12 +34,12 @@ class ActionLogBuilder {
     this.doActionLogs = new ArrayList<>();
   }
 
-  ActionLogBuilder addSuccessActionLog(long duration, ActionLog actionLog){
+  ActionLogBuilder appendInvocationLogEntry(long duration, ActionLog actionLog){
     doActionLogs.add(success(duration, actionLog));
     return this;
   }
 
-  ActionLogBuilder addFailedActionLog(long duration, ActionLog actionLog){
+  ActionLogBuilder appendFailureInvocationLogEntry(long duration, ActionLog actionLog){
     doActionLogs.add(error(duration,  actionLog));
     return this;
   }

--- a/handler/api/src/main/java/io/knotx/fragments/handler/api/actionlog/ActionLogBuilder.java
+++ b/handler/api/src/main/java/io/knotx/fragments/handler/api/actionlog/ActionLogBuilder.java
@@ -20,13 +20,14 @@ import static io.knotx.fragments.handler.api.actionlog.ActionInvocationLog.succe
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Stream;
 
 import io.vertx.core.json.JsonObject;
 
 class ActionLogBuilder {
   private String alias;
   private JsonObject logs;
-  private List<ActionInvocationLog> doActionLogs;
+  private ArrayList<ActionInvocationLog> doActionLogs;
 
   ActionLogBuilder(String alias){
     this.alias = alias;
@@ -55,6 +56,7 @@ class ActionLogBuilder {
   }
 
   ActionLog build(){
+    Stream.of(doActionLogs.toArray());
     return new ActionLog(alias, logs, doActionLogs);
   }
 }

--- a/handler/api/src/main/java/io/knotx/fragments/handler/api/actionlog/ActionLogBuilder.java
+++ b/handler/api/src/main/java/io/knotx/fragments/handler/api/actionlog/ActionLogBuilder.java
@@ -15,28 +15,36 @@
  */
 package io.knotx.fragments.handler.api.actionlog;
 
+import static io.knotx.fragments.handler.api.actionlog.ActionInvocationLog.error;
+import static io.knotx.fragments.handler.api.actionlog.ActionInvocationLog.success;
+
 import java.util.ArrayList;
 import java.util.List;
 
 import io.vertx.core.json.JsonObject;
 
-public class ActionLogBuilder {
+class ActionLogBuilder {
   private String alias;
   private JsonObject logs;
-  private List<ActionLog> doActionLogs;
+  private List<ActionInvocationLog> doActionLogs;
 
-  public ActionLogBuilder(String alias){
+  ActionLogBuilder(String alias){
     this.alias = alias;
     this.logs = new JsonObject();
     this.doActionLogs = new ArrayList<>();
   }
 
-  ActionLogBuilder addActionLog(ActionLog actionLog){
-    doActionLogs.add(actionLog);
+  ActionLogBuilder addSuccessActionLog(long duration, ActionLog actionLog){
+    doActionLogs.add(success(duration, actionLog));
     return this;
   }
 
-  public ActionLogBuilder addLog(String key, String value){
+  ActionLogBuilder addFailedActionLog(long duration, ActionLog actionLog){
+    doActionLogs.add(error(duration,  actionLog));
+    return this;
+  }
+
+  ActionLogBuilder addLog(String key, String value){
     logs.put(key, value);
     return this;
   }
@@ -46,8 +54,7 @@ public class ActionLogBuilder {
     return this;
   }
 
-  public ActionLog build(){
+  ActionLog build(){
     return new ActionLog(alias, logs, doActionLogs);
   }
-
 }

--- a/handler/api/src/main/java/io/knotx/fragments/handler/api/actionlog/ActionLogLevel.java
+++ b/handler/api/src/main/java/io/knotx/fragments/handler/api/actionlog/ActionLogLevel.java
@@ -24,7 +24,7 @@ import io.vertx.core.json.JsonObject;
 public enum ActionLogLevel {
   INFO("info"), ERROR("error");
 
-
+  private static final String CONFIG_KEY_NAME = "logLevel";
   private final String level;
 
   ActionLogLevel(String level) {

--- a/handler/api/src/main/java/io/knotx/fragments/handler/api/actionlog/ActionLogLevel.java
+++ b/handler/api/src/main/java/io/knotx/fragments/handler/api/actionlog/ActionLogLevel.java
@@ -19,6 +19,8 @@ import static java.lang.String.format;
 
 import java.util.Arrays;
 
+import io.vertx.core.json.JsonObject;
+
 public enum ActionLogLevel {
   INFO("info"), ERROR("error");
 
@@ -33,6 +35,9 @@ public enum ActionLogLevel {
     return level;
   }
 
+  public static  ActionLogLevel fromConfig(JsonObject config){
+    return  fromConfig(config.getString(CONFIG_KEY_NAME));
+  }
   public static ActionLogLevel fromConfig(String level) {
     return Arrays.asList(ActionLogLevel.values())
         .stream()

--- a/handler/api/src/main/java/io/knotx/fragments/handler/api/actionlog/ActionLogLevel.java
+++ b/handler/api/src/main/java/io/knotx/fragments/handler/api/actionlog/ActionLogLevel.java
@@ -35,9 +35,10 @@ public enum ActionLogLevel {
     return level;
   }
 
-  public static  ActionLogLevel fromConfig(JsonObject config){
-    return  fromConfig(config.getString(CONFIG_KEY_NAME));
+  public static ActionLogLevel fromConfig(JsonObject config) {
+    return fromConfig(config.getString(CONFIG_KEY_NAME));
   }
+
   public static ActionLogLevel fromConfig(String level) {
     return Arrays.asList(ActionLogLevel.values())
         .stream()

--- a/handler/api/src/main/java/io/knotx/fragments/handler/api/actionlog/ActionLogger.java
+++ b/handler/api/src/main/java/io/knotx/fragments/handler/api/actionlog/ActionLogger.java
@@ -20,6 +20,7 @@ import static io.knotx.fragments.handler.api.actionlog.ActionLogLevel.INFO;
 import io.vertx.core.json.JsonObject;
 import java.time.Instant;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.function.Function;
 
 public class ActionLogger {
@@ -69,11 +70,16 @@ public class ActionLogger {
     }
   }
 
-  public void doActionLog(ActionLog actionLog) {
-    if(Objects.isNull(actionLog)){
-      return;
-    }
-    this.builder.addActionLog(actionLog);
+  public void doActionLog(long duration, JsonObject actionLog) {
+    this.builder.addSuccessActionLog(duration, toActionLog(actionLog));
+  }
+
+  private ActionLog toActionLog(JsonObject jsonObject){
+    return Optional.ofNullable(jsonObject).map(ActionLog::new).orElse(null);
+  }
+
+  public void failedDoActionLog(long duration, JsonObject actionLog) {
+    this.builder.addFailedActionLog(duration, toActionLog(actionLog));
   }
 
   public void error(String key, JsonObject data) {

--- a/handler/api/src/main/java/io/knotx/fragments/handler/api/actionlog/ActionLogger.java
+++ b/handler/api/src/main/java/io/knotx/fragments/handler/api/actionlog/ActionLogger.java
@@ -19,7 +19,6 @@ import static io.knotx.fragments.handler.api.actionlog.ActionLogLevel.INFO;
 
 import io.vertx.core.json.JsonObject;
 import java.time.Instant;
-import java.util.Optional;
 import java.util.function.Function;
 
 public class ActionLogger {
@@ -71,16 +70,16 @@ public class ActionLogger {
 
   public void doActionLog(long duration, JsonObject actionLog) {
     if (actionLogLevel == INFO) {
-      this.builder.appendInvocationLogEntry(duration, toActionLog(actionLog));
+      this.builder.appendInvocationLogEntry(duration, toActionLogOrNull(actionLog));
     }
   }
 
-  private ActionLog toActionLog(JsonObject jsonObject){
-    return Optional.ofNullable(jsonObject).map(ActionLog::new).orElse(null);
+  private ActionLog toActionLogOrNull(JsonObject jsonObject){
+    return jsonObject != null ? new ActionLog(jsonObject) : null;
   }
 
   public void failureDoActionLog(long duration, JsonObject actionLog) {
-    this.builder.appendFailureInvocationLogEntry(duration, toActionLog(actionLog));
+    this.builder.appendFailureInvocationLogEntry(duration, toActionLogOrNull(actionLog));
   }
 
   public void error(String key, JsonObject data) {

--- a/handler/api/src/main/java/io/knotx/fragments/handler/api/actionlog/ActionLogger.java
+++ b/handler/api/src/main/java/io/knotx/fragments/handler/api/actionlog/ActionLogger.java
@@ -70,7 +70,9 @@ public class ActionLogger {
   }
 
   public void doActionLog(long duration, JsonObject actionLog) {
-    this.builder.appendInvocationLogEntry(duration, toActionLog(actionLog));
+    if (actionLogLevel == INFO) {
+      this.builder.appendInvocationLogEntry(duration, toActionLog(actionLog));
+    }
   }
 
   private ActionLog toActionLog(JsonObject jsonObject){

--- a/handler/api/src/main/java/io/knotx/fragments/handler/api/actionlog/ActionLogger.java
+++ b/handler/api/src/main/java/io/knotx/fragments/handler/api/actionlog/ActionLogger.java
@@ -19,7 +19,6 @@ import static io.knotx.fragments.handler.api.actionlog.ActionLogLevel.INFO;
 
 import io.vertx.core.json.JsonObject;
 import java.time.Instant;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
 
@@ -71,15 +70,15 @@ public class ActionLogger {
   }
 
   public void doActionLog(long duration, JsonObject actionLog) {
-    this.builder.addSuccessActionLog(duration, toActionLog(actionLog));
+    this.builder.appendInvocationLogEntry(duration, toActionLog(actionLog));
   }
 
   private ActionLog toActionLog(JsonObject jsonObject){
     return Optional.ofNullable(jsonObject).map(ActionLog::new).orElse(null);
   }
 
-  public void failedDoActionLog(long duration, JsonObject actionLog) {
-    this.builder.addFailedActionLog(duration, toActionLog(actionLog));
+  public void failureDoActionLog(long duration, JsonObject actionLog) {
+    this.builder.appendFailureInvocationLogEntry(duration, toActionLog(actionLog));
   }
 
   public void error(String key, JsonObject data) {

--- a/handler/api/src/test/java/io/knotx/fragments/handler/api/actionlog/ActionInvocationLogTest.java
+++ b/handler/api/src/test/java/io/knotx/fragments/handler/api/actionlog/ActionInvocationLogTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2019 Knot.x Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.knotx.fragments.handler.api.actionlog;
 
 

--- a/handler/api/src/test/java/io/knotx/fragments/handler/api/actionlog/ActionInvocationLogTest.java
+++ b/handler/api/src/test/java/io/knotx/fragments/handler/api/actionlog/ActionInvocationLogTest.java
@@ -1,0 +1,48 @@
+package io.knotx.fragments.handler.api.actionlog;
+
+
+import static io.knotx.fragments.handler.api.actionlog.ActionInvocationLog.DO_ACTION_LOG;
+import static io.knotx.fragments.handler.api.actionlog.ActionInvocationLog.DURATION;
+import static io.knotx.fragments.handler.api.actionlog.ActionInvocationLog.SUCCESS;
+import static java.util.Collections.EMPTY_LIST;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import io.vertx.core.json.JsonObject;
+
+class ActionInvocationLogTest {
+
+  @Test
+  @DisplayName("Expect null actionLog when json does not contain such key")
+  void expectNullActionLog() {
+    //given
+    JsonObject json = new JsonObject().put(DURATION, 1L).put(SUCCESS, true);
+
+    //when
+    ActionInvocationLog invocationLog = new ActionInvocationLog(json);
+
+    //then
+    assertNull(invocationLog.getDoActionLog());
+    assertNull(invocationLog.toJson().getJsonObject(DO_ACTION_LOG));
+  }
+
+  @Test
+  @DisplayName("Expect not null actionLog when json contains such key")
+  void expectNotNullActionLog() {
+    //given
+    ActionLog al = new ActionLog("alias", new JsonObject(), EMPTY_LIST);
+    JsonObject json = new JsonObject().put(DURATION, 1L)
+        .put(SUCCESS, true)
+        .put(DO_ACTION_LOG, al.toJson());
+
+    //when
+    ActionInvocationLog invocationLog = new ActionInvocationLog(json);
+
+    //then
+    assertNotNull(invocationLog.getDoActionLog());
+    assertNotNull(invocationLog.toJson().getJsonObject(DO_ACTION_LOG));
+  }
+}

--- a/handler/core/build.gradle.kts
+++ b/handler/core/build.gradle.kts
@@ -44,6 +44,7 @@ dependencies {
     testImplementation(group = "io.vertx", name = "vertx-web-client")
     testImplementation(group = "io.vertx", name = "vertx-rx-java2")
     testImplementation(group = "io.vertx", name = "vertx-config-hocon")
+    testImplementation("org.junit.jupiter:junit-jupiter-params")
 }
 
 tasks {

--- a/handler/core/docs/asciidoc/dataobjects.adoc
+++ b/handler/core/docs/asciidoc/dataobjects.adoc
@@ -63,6 +63,26 @@ The dictionary maps action name to action factory options.
 +++
 |===
 
+[[CircuitBreakerActionFactoryOptions]]
+== CircuitBreakerActionFactoryOptions
+
+
+[cols=">25%,25%,50%"]
+[frame="topbot"]
+|===
+^|Name | Type ^| Description
+|[[circuitBreakerName]]`@circuitBreakerName`|`String`|+++
+Sets the circuit breaker name.
++++
+|[[circuitBreakerOptions]]`@circuitBreakerOptions`|`link:dataobjects.html#CircuitBreakerOptions[CircuitBreakerOptions]`|+++
+Sets the circuit breaker configuration options. Note that Knot.x enforce the fallback on error
+ strategy.
++++
+|[[logLevel]]`@logLevel`|`String`|+++
+Sets the action node log level.
++++
+|===
+
 [[DefaultTaskFactoryConfig]]
 == DefaultTaskFactoryConfig
 

--- a/handler/core/src/main/java/io/knotx/fragments/handler/action/CircuitBreakerActionFactory.java
+++ b/handler/core/src/main/java/io/knotx/fragments/handler/action/CircuitBreakerActionFactory.java
@@ -70,7 +70,8 @@ public class CircuitBreakerActionFactory implements ActionFactory {
     CircuitBreaker circuitBreaker = new CircuitBreakerImpl(circuitBreakerName, vertx,
         circuitBreakerOptions);
 
-    return new CircuitBreakerAction(circuitBreaker, doAction, alias, fromConfig(config), errorTransition);
+    return new CircuitBreakerAction(circuitBreaker, doAction, alias, fromConfig(config),
+        errorTransition);
   }
 
   public static class CircuitBreakerAction implements Action {
@@ -113,22 +114,23 @@ public class CircuitBreakerActionFactory implements ActionFactory {
     private void doActionResultHandler(Promise<FragmentResult> promise,
         FragmentResult result, int invocation, long startTime, ActionLogger actionLogger) {
       if (isError(result)) {
-        handleFail(promise, result, invocation, startTime, actionLogger);
+        handleFail(promise, result, startTime, actionLogger);
       } else {
         handleSuccess(promise, result, invocation, startTime, actionLogger);
       }
     }
 
-    private boolean isError(FragmentResult result){
+    private boolean isError(FragmentResult result) {
       return errorTransition.equals(result.getTransition());
     }
+
     private void handleFail(Promise<FragmentResult> f, FragmentResult result,
-        int invocation, long startTime, ActionLogger actionLogger) {
-      actionLogger.failedDoActionLog(executionTime(startTime),  result.getNodeLog());
+        long startTime, ActionLogger actionLogger) {
+      actionLogger.failedDoActionLog(executionTime(startTime), result.getNodeLog());
       f.fail(new DoActionExecuteException(format("Action end up %s transition", errorTransition)));
     }
 
-    private static long executionTime(long startTime){
+    private static long executionTime(long startTime) {
       return now().toEpochMilli() - startTime;
     }
 
@@ -145,7 +147,8 @@ public class CircuitBreakerActionFactory implements ActionFactory {
       Fragment fragment = fragmentContext.getFragment();
       actionLogger.info("invocationCount", valueOf(counter.get()));
       actionLogger
-          .error("fallback", format("Exception: %s. %s", throwable.getClass(), throwable.getLocalizedMessage()));
+          .error("fallback",
+              format("Exception: %s. %s", throwable.getClass(), throwable.getLocalizedMessage()));
       return new FragmentResult(fragment, FALLBACK_TRANSITION, actionLogger.toLog().toJson());
     }
   }

--- a/handler/core/src/main/java/io/knotx/fragments/handler/action/CircuitBreakerActionFactory.java
+++ b/handler/core/src/main/java/io/knotx/fragments/handler/action/CircuitBreakerActionFactory.java
@@ -77,6 +77,8 @@ public class CircuitBreakerActionFactory implements ActionFactory {
 
   public static class CircuitBreakerAction implements Action {
 
+    public static final String INVOCATION_COUNT_LOG_KEY = "invocationCount";
+    public static final String ERROR_LOG_KEY = "error";
     private final CircuitBreaker circuitBreaker;
     private final Action doAction;
     private final ActionLogLevel actionLogLevel;
@@ -145,7 +147,7 @@ public class CircuitBreakerActionFactory implements ActionFactory {
 
     private static void handleSuccess(Promise<FragmentResult> f, FragmentResult result,
         AtomicInteger counter, long startTime, ActionLogger actionLogger) {
-      actionLogger.info("invocationCount", valueOf(counter.get()));
+      actionLogger.info(INVOCATION_COUNT_LOG_KEY, valueOf(counter.get()));
       actionLogger.doActionLog(executionTime(startTime), result.getNodeLog());
       f.complete(new FragmentResult(result.getFragment(), result.getTransition(),
           actionLogger.toLog().toJson()));
@@ -163,9 +165,9 @@ public class CircuitBreakerActionFactory implements ActionFactory {
 
     private static void logFallback(Throwable throwable, AtomicInteger counter,
         ActionLogger actionLogger) {
-      actionLogger.info("invocationCount", valueOf(counter.get()));
+      actionLogger.info(INVOCATION_COUNT_LOG_KEY, valueOf(counter.get()));
       actionLogger
-          .error("fallback",
+          .error(ERROR_LOG_KEY,
               format("Exception: %s. %s", throwable.getClass(), throwable.getLocalizedMessage()));
     }
   }

--- a/handler/core/src/main/java/io/knotx/fragments/handler/action/CircuitBreakerActionFactory.java
+++ b/handler/core/src/main/java/io/knotx/fragments/handler/action/CircuitBreakerActionFactory.java
@@ -15,18 +15,31 @@
  */
 package io.knotx.fragments.handler.action;
 
+import static io.knotx.fragments.handler.api.actionlog.ActionLogLevel.fromConfig;
+import static io.knotx.fragments.handler.api.domain.FragmentResult.ERROR_TRANSITION;
+import static java.lang.String.format;
+import static java.lang.String.valueOf;
+import static java.time.Instant.now;
+import static java.util.Objects.isNull;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
 import io.knotx.fragments.api.Fragment;
 import io.knotx.fragments.handler.api.Action;
 import io.knotx.fragments.handler.api.ActionFactory;
 import io.knotx.fragments.handler.api.Cacheable;
+import io.knotx.fragments.handler.api.actionlog.ActionLogLevel;
+import io.knotx.fragments.handler.api.actionlog.ActionLogger;
 import io.knotx.fragments.handler.api.domain.FragmentContext;
 import io.knotx.fragments.handler.api.domain.FragmentResult;
+import io.knotx.fragments.handler.exception.DoActionExecuteException;
 import io.knotx.fragments.handler.exception.DoActionNotDefinedException;
 import io.vertx.circuitbreaker.CircuitBreaker;
 import io.vertx.circuitbreaker.CircuitBreakerOptions;
 import io.vertx.circuitbreaker.impl.CircuitBreakerImpl;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
+import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
 
@@ -46,46 +59,94 @@ public class CircuitBreakerActionFactory implements ActionFactory {
 
   @Override
   public Action create(String alias, JsonObject config, Vertx vertx, Action doAction) {
-    if (doAction == null) {
+    if (isNull(doAction)) {
       throw new DoActionNotDefinedException("Circuit Breaker action requires `doAction` defined");
     }
     String circuitBreakerName = config.getString("circuitBreakerName");
+    String errorTransition = config.getString("errorTransition", ERROR_TRANSITION);
     CircuitBreakerOptions circuitBreakerOptions =
         config.getJsonObject("circuitBreakerOptions") == null ? new CircuitBreakerOptions()
             : new CircuitBreakerOptions(config.getJsonObject("circuitBreakerOptions"));
     CircuitBreaker circuitBreaker = new CircuitBreakerImpl(circuitBreakerName, vertx,
         circuitBreakerOptions);
 
-    return new CircuitBreakerAction(circuitBreaker, doAction);
+    return new CircuitBreakerAction(circuitBreaker, doAction, alias, fromConfig(config), errorTransition);
   }
 
   public static class CircuitBreakerAction implements Action {
 
-    private CircuitBreaker circuitBreaker;
-    private Action doAction;
+    private final CircuitBreaker circuitBreaker;
+    private final Action doAction;
+    private final ActionLogLevel actionLogLevel;
+    private final String alias;
+    private final String errorTransition;
 
-    CircuitBreakerAction(CircuitBreaker circuitBreaker, Action doAction) {
+    CircuitBreakerAction(CircuitBreaker circuitBreaker, Action doAction, String alias,
+        ActionLogLevel actionLogLevel, String errorTransition) {
       this.circuitBreaker = circuitBreaker;
       this.doAction = doAction;
+      this.alias = alias;
+      this.actionLogLevel = actionLogLevel;
+      this.errorTransition = errorTransition;
     }
 
     @Override
     public void apply(FragmentContext fragmentContext,
         Handler<AsyncResult<FragmentResult>> resultHandler) {
+      AtomicInteger counter = new AtomicInteger();
+      ActionLogger actionLogger = ActionLogger.create(alias, actionLogLevel);
+
       circuitBreaker.executeWithFallback(
-          f -> doAction.apply(fragmentContext,
-              result -> {
-                if (result.succeeded()) {
-                  f.complete(result.result());
-                } else {
-                  f.fail(result.cause());
-                }
-              }),
-          v -> {
-            Fragment fragment = fragmentContext.getFragment();
-            return new FragmentResult(fragment, FALLBACK_TRANSITION);
-          }
+          promise -> executeCommand(promise, fragmentContext, counter, actionLogger),
+          throwable -> handleFallback(fragmentContext, throwable, counter, actionLogger)
       ).setHandler(resultHandler);
+    }
+
+    private void executeCommand(Promise<FragmentResult> f, FragmentContext fragmentContext,
+        AtomicInteger counter, ActionLogger actionLogger) {
+      int index = counter.addAndGet(1);
+      long startTime = now().toEpochMilli();
+      doAction.apply(fragmentContext,
+          result -> doActionResultHandler(f, result.result(), index, startTime, actionLogger));
+    }
+
+    private void doActionResultHandler(Promise<FragmentResult> promise,
+        FragmentResult result, int invocation, long startTime, ActionLogger actionLogger) {
+      if (isError(result)) {
+        handleFail(promise, result, invocation, startTime, actionLogger);
+      } else {
+        handleSuccess(promise, result, invocation, startTime, actionLogger);
+      }
+    }
+
+    private boolean isError(FragmentResult result){
+      return errorTransition.equals(result.getTransition());
+    }
+    private void handleFail(Promise<FragmentResult> f, FragmentResult result,
+        int invocation, long startTime, ActionLogger actionLogger) {
+      actionLogger.failedDoActionLog(executionTime(startTime),  result.getNodeLog());
+      f.fail(new DoActionExecuteException(format("Action end up %s transition", errorTransition)));
+    }
+
+    private static long executionTime(long startTime){
+      return now().toEpochMilli() - startTime;
+    }
+
+    private void handleSuccess(Promise<FragmentResult> f, FragmentResult result,
+        int invocation, long startTime, ActionLogger actionLogger) {
+      actionLogger.info("invocationCount", valueOf(invocation));
+      actionLogger.doActionLog(executionTime(startTime), result.getNodeLog());
+      f.complete(new FragmentResult(result.getFragment(), result.getTransition(),
+          actionLogger.toLog().toJson()));
+    }
+
+    private FragmentResult handleFallback(FragmentContext fragmentContext, Throwable throwable,
+        AtomicInteger counter, ActionLogger actionLogger) {
+      Fragment fragment = fragmentContext.getFragment();
+      actionLogger.info("invocationCount", valueOf(counter.get()));
+      actionLogger
+          .error("fallback", format("Exception: %s. %s", throwable.getClass(), throwable.getLocalizedMessage()));
+      return new FragmentResult(fragment, FALLBACK_TRANSITION, actionLogger.toLog().toJson());
     }
   }
 }

--- a/handler/core/src/main/java/io/knotx/fragments/handler/action/CircuitBreakerActionFactory.java
+++ b/handler/core/src/main/java/io/knotx/fragments/handler/action/CircuitBreakerActionFactory.java
@@ -134,7 +134,7 @@ public class CircuitBreakerActionFactory implements ActionFactory {
     }
 
     private boolean isErrorTransition(FragmentResult result) {
-      return errorTransition.equals(result.getTransition());
+      return ERROR_TRANSITION.equals(result.getTransition()) || errorTransition.equals(result.getTransition());
     }
 
     private static void handleFail(Promise<FragmentResult> promise, JsonObject nodeLog,

--- a/handler/core/src/main/java/io/knotx/fragments/handler/action/CircuitBreakerActionFactory.java
+++ b/handler/core/src/main/java/io/knotx/fragments/handler/action/CircuitBreakerActionFactory.java
@@ -22,7 +22,6 @@ import static java.lang.String.valueOf;
 import static java.time.Instant.now;
 import static java.util.Objects.isNull;
 
-import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import io.knotx.fragments.api.Fragment;
@@ -140,7 +139,7 @@ public class CircuitBreakerActionFactory implements ActionFactory {
 
     private static void handleFail(Promise<FragmentResult> promise, JsonObject nodeLog,
         long startTime, String error, ActionLogger actionLogger) {
-      actionLogger.failedDoActionLog(executionTime(startTime), nodeLog);
+      actionLogger.failureDoActionLog(executionTime(startTime), nodeLog);
       promise.fail(new DoActionExecuteException(error));
     }
 

--- a/handler/core/src/main/java/io/knotx/fragments/handler/action/cb/CircuitBreakerAction.java
+++ b/handler/core/src/main/java/io/knotx/fragments/handler/action/cb/CircuitBreakerAction.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2019 Knot.x Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.knotx.fragments.handler.action.cb;
 
 import static io.knotx.fragments.handler.action.cb.CircuitBreakerActionFactory.FALLBACK_TRANSITION;
@@ -23,8 +38,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 class CircuitBreakerAction implements Action {
 
-  private static final String INVOCATION_COUNT_LOG_KEY = "invocationCount";
-  private static final String ERROR_LOG_KEY = "error";
+  static final String INVOCATION_COUNT_LOG_KEY = "invocationCount";
+  static final String ERROR_LOG_KEY = "error";
   private final CircuitBreaker circuitBreaker;
   private final Action doAction;
   private final ActionLogLevel actionLogLevel;

--- a/handler/core/src/main/java/io/knotx/fragments/handler/action/cb/CircuitBreakerAction.java
+++ b/handler/core/src/main/java/io/knotx/fragments/handler/action/cb/CircuitBreakerAction.java
@@ -1,0 +1,122 @@
+package io.knotx.fragments.handler.action.cb;
+
+import static io.knotx.fragments.handler.action.cb.CircuitBreakerActionFactory.FALLBACK_TRANSITION;
+import static io.knotx.fragments.handler.api.domain.FragmentResult.ERROR_TRANSITION;
+import static java.lang.String.format;
+import static java.lang.String.valueOf;
+import static java.time.Instant.now;
+
+import io.knotx.fragments.api.Fragment;
+import io.knotx.fragments.handler.api.Action;
+import io.knotx.fragments.handler.api.actionlog.ActionLog;
+import io.knotx.fragments.handler.api.actionlog.ActionLogLevel;
+import io.knotx.fragments.handler.api.actionlog.ActionLogger;
+import io.knotx.fragments.handler.api.domain.FragmentContext;
+import io.knotx.fragments.handler.api.domain.FragmentResult;
+import io.knotx.fragments.handler.exception.DoActionExecuteException;
+import io.vertx.circuitbreaker.CircuitBreaker;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
+import io.vertx.core.Promise;
+import io.vertx.core.json.JsonObject;
+import java.util.concurrent.atomic.AtomicInteger;
+
+class CircuitBreakerAction implements Action {
+
+  private static final String INVOCATION_COUNT_LOG_KEY = "invocationCount";
+  private static final String ERROR_LOG_KEY = "error";
+  private final CircuitBreaker circuitBreaker;
+  private final Action doAction;
+  private final ActionLogLevel actionLogLevel;
+  private final String alias;
+
+  CircuitBreakerAction(CircuitBreaker circuitBreaker, Action doAction, String alias,
+      ActionLogLevel actionLogLevel) {
+    this.circuitBreaker = circuitBreaker;
+    this.doAction = doAction;
+    this.alias = alias;
+    this.actionLogLevel = actionLogLevel;
+  }
+
+  @Override
+  public void apply(FragmentContext fragmentContext,
+      Handler<AsyncResult<FragmentResult>> resultHandler) {
+    AtomicInteger counter = new AtomicInteger();
+    ActionLogger actionLogger = ActionLogger.create(alias, actionLogLevel);
+    circuitBreaker.executeWithFallback(
+        promise -> executeCommand(promise, fragmentContext, counter, actionLogger),
+        throwable -> handleFallback(fragmentContext, throwable, counter, actionLogger)
+    ).setHandler(resultHandler);
+  }
+
+  private void executeCommand(Promise<FragmentResult> promise, FragmentContext fragmentContext,
+      AtomicInteger counter, ActionLogger actionLogger) {
+    counter.incrementAndGet();
+    long startTime = now().toEpochMilli();
+    try {
+      doAction.apply(fragmentContext,
+          result -> {
+            if (result.succeeded()) {
+              handleResult(promise, result.result(), counter, startTime, actionLogger);
+            } else {
+              handleFail(promise, null, startTime, result.cause(), actionLogger);
+            }
+          });
+    } catch (Exception e) {
+      handleFail(promise, null, startTime, e, actionLogger);
+      throw e;
+    }
+  }
+
+  private void handleResult(Promise<FragmentResult> promise,
+      FragmentResult result, AtomicInteger counter, long startTime,
+      ActionLogger actionLogger) {
+    if (isErrorTransition(result)) {
+      handleFail(promise, result.getNodeLog(), startTime,
+          new DoActionExecuteException(format("Action end up %s transition", ERROR_TRANSITION)),
+          actionLogger);
+    } else {
+      handleSuccess(promise, result, counter, startTime, actionLogger);
+    }
+  }
+
+  private boolean isErrorTransition(FragmentResult result) {
+    return ERROR_TRANSITION.equals(result.getTransition());
+  }
+
+  private static void handleFail(Promise<FragmentResult> promise, JsonObject nodeLog,
+      long startTime, Throwable error, ActionLogger actionLogger) {
+    actionLogger.failureDoActionLog(executionTime(startTime), nodeLog);
+    promise.fail(error);
+  }
+
+  private static long executionTime(long startTime) {
+    return now().toEpochMilli() - startTime;
+  }
+
+  private static void handleSuccess(Promise<FragmentResult> f, FragmentResult result,
+      AtomicInteger counter, long startTime, ActionLogger actionLogger) {
+    actionLogger.info(INVOCATION_COUNT_LOG_KEY, valueOf(counter.get()));
+    actionLogger.doActionLog(executionTime(startTime), result.getNodeLog());
+    f.complete(new FragmentResult(result.getFragment(), result.getTransition(),
+        actionLogger.toLog().toJson()));
+  }
+
+  private static FragmentResult handleFallback(FragmentContext fragmentContext,
+      Throwable throwable,
+      AtomicInteger counter, ActionLogger actionLogger) {
+    logFallback(throwable, counter, actionLogger);
+    Fragment fragment = fragmentContext.getFragment();
+    ActionLog actionLog = actionLogger.toLog();
+    return new FragmentResult(fragment, FALLBACK_TRANSITION, actionLog.toJson());
+  }
+
+
+  private static void logFallback(Throwable throwable, AtomicInteger counter,
+      ActionLogger actionLogger) {
+    actionLogger.error(INVOCATION_COUNT_LOG_KEY, valueOf(counter.get()));
+    actionLogger
+        .error(ERROR_LOG_KEY,
+            format("Exception: %s. %s", throwable.getClass(), throwable.getLocalizedMessage()));
+  }
+}

--- a/handler/core/src/main/java/io/knotx/fragments/handler/action/cb/CircuitBreakerActionFactory.java
+++ b/handler/core/src/main/java/io/knotx/fragments/handler/action/cb/CircuitBreakerActionFactory.java
@@ -49,7 +49,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 @Cacheable
 public class CircuitBreakerActionFactory implements ActionFactory {
 
-  static final String FALLBACK_TRANSITION = "fallback";
+  static final String FALLBACK_TRANSITION = "_fallback";
   static final String FACTORY_NAME = "cb";
 
   @Override

--- a/handler/core/src/main/java/io/knotx/fragments/handler/action/cb/CircuitBreakerActionFactory.java
+++ b/handler/core/src/main/java/io/knotx/fragments/handler/action/cb/CircuitBreakerActionFactory.java
@@ -16,31 +16,16 @@
 package io.knotx.fragments.handler.action.cb;
 
 import static io.knotx.fragments.handler.api.actionlog.ActionLogLevel.fromConfig;
-import static io.knotx.fragments.handler.api.domain.FragmentResult.ERROR_TRANSITION;
-import static java.lang.String.format;
-import static java.lang.String.valueOf;
-import static java.time.Instant.now;
 import static java.util.Objects.isNull;
 
-import io.knotx.fragments.api.Fragment;
 import io.knotx.fragments.handler.api.Action;
 import io.knotx.fragments.handler.api.ActionFactory;
 import io.knotx.fragments.handler.api.Cacheable;
-import io.knotx.fragments.handler.api.actionlog.ActionLog;
-import io.knotx.fragments.handler.api.actionlog.ActionLogLevel;
-import io.knotx.fragments.handler.api.actionlog.ActionLogger;
-import io.knotx.fragments.handler.api.domain.FragmentContext;
-import io.knotx.fragments.handler.api.domain.FragmentResult;
-import io.knotx.fragments.handler.exception.DoActionExecuteException;
 import io.knotx.fragments.handler.exception.DoActionNotDefinedException;
 import io.vertx.circuitbreaker.CircuitBreaker;
 import io.vertx.circuitbreaker.impl.CircuitBreakerImpl;
-import io.vertx.core.AsyncResult;
-import io.vertx.core.Handler;
-import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
-import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * This is a factory class creating action, which provides circuit breaker mechanism. It protects
@@ -68,105 +53,5 @@ public class CircuitBreakerActionFactory implements ActionFactory {
 
     return new CircuitBreakerAction(circuitBreaker, doAction, alias,
         fromConfig(options.getLogLevel()));
-  }
-
-  public static class CircuitBreakerAction implements Action {
-
-    public static final String INVOCATION_COUNT_LOG_KEY = "invocationCount";
-    public static final String ERROR_LOG_KEY = "error";
-    private final CircuitBreaker circuitBreaker;
-    private final Action doAction;
-    private final ActionLogLevel actionLogLevel;
-    private final String alias;
-
-    CircuitBreakerAction(CircuitBreaker circuitBreaker, Action doAction, String alias,
-        ActionLogLevel actionLogLevel) {
-      this.circuitBreaker = circuitBreaker;
-      this.doAction = doAction;
-      this.alias = alias;
-      this.actionLogLevel = actionLogLevel;
-    }
-
-    @Override
-    public void apply(FragmentContext fragmentContext,
-        Handler<AsyncResult<FragmentResult>> resultHandler) {
-      AtomicInteger counter = new AtomicInteger();
-      ActionLogger actionLogger = ActionLogger.create(alias, actionLogLevel);
-      circuitBreaker.executeWithFallback(
-          promise -> executeCommand(promise, fragmentContext, counter, actionLogger),
-          throwable -> handleFallback(fragmentContext, throwable, counter, actionLogger)
-      ).setHandler(resultHandler);
-    }
-
-    private void executeCommand(Promise<FragmentResult> promise, FragmentContext fragmentContext,
-        AtomicInteger counter, ActionLogger actionLogger) {
-      counter.incrementAndGet();
-      long startTime = now().toEpochMilli();
-      try {
-        doAction.apply(fragmentContext,
-            result -> {
-              if (result.succeeded()) {
-                handleResult(promise, result.result(), counter, startTime, actionLogger);
-              } else {
-                handleFail(promise, null, startTime, result.cause(), actionLogger);
-              }
-            });
-      } catch (Exception e) {
-        handleFail(promise, null, startTime, e, actionLogger);
-        throw e;
-      }
-    }
-
-    private void handleResult(Promise<FragmentResult> promise,
-        FragmentResult result, AtomicInteger counter, long startTime,
-        ActionLogger actionLogger) {
-      if (isErrorTransition(result)) {
-        handleFail(promise, result.getNodeLog(), startTime,
-            new DoActionExecuteException(format("Action end up %s transition", ERROR_TRANSITION)),
-            actionLogger);
-      } else {
-        handleSuccess(promise, result, counter, startTime, actionLogger);
-      }
-    }
-
-    private boolean isErrorTransition(FragmentResult result) {
-      return ERROR_TRANSITION.equals(result.getTransition());
-    }
-
-    private static void handleFail(Promise<FragmentResult> promise, JsonObject nodeLog,
-        long startTime, Throwable error, ActionLogger actionLogger) {
-      actionLogger.failureDoActionLog(executionTime(startTime), nodeLog);
-      promise.fail(error);
-    }
-
-    private static long executionTime(long startTime) {
-      return now().toEpochMilli() - startTime;
-    }
-
-    private static void handleSuccess(Promise<FragmentResult> f, FragmentResult result,
-        AtomicInteger counter, long startTime, ActionLogger actionLogger) {
-      actionLogger.info(INVOCATION_COUNT_LOG_KEY, valueOf(counter.get()));
-      actionLogger.doActionLog(executionTime(startTime), result.getNodeLog());
-      f.complete(new FragmentResult(result.getFragment(), result.getTransition(),
-          actionLogger.toLog().toJson()));
-    }
-
-    private static FragmentResult handleFallback(FragmentContext fragmentContext,
-        Throwable throwable,
-        AtomicInteger counter, ActionLogger actionLogger) {
-      logFallback(throwable, counter, actionLogger);
-      Fragment fragment = fragmentContext.getFragment();
-      ActionLog actionLog = actionLogger.toLog();
-      return new FragmentResult(fragment, FALLBACK_TRANSITION, actionLog.toJson());
-    }
-
-
-    private static void logFallback(Throwable throwable, AtomicInteger counter,
-        ActionLogger actionLogger) {
-      actionLogger.error(INVOCATION_COUNT_LOG_KEY, valueOf(counter.get()));
-      actionLogger
-          .error(ERROR_LOG_KEY,
-              format("Exception: %s. %s", throwable.getClass(), throwable.getLocalizedMessage()));
-    }
   }
 }

--- a/handler/core/src/main/java/io/knotx/fragments/handler/action/cb/CircuitBreakerActionFactory.java
+++ b/handler/core/src/main/java/io/knotx/fragments/handler/action/cb/CircuitBreakerActionFactory.java
@@ -50,10 +50,11 @@ import java.util.concurrent.atomic.AtomicInteger;
 public class CircuitBreakerActionFactory implements ActionFactory {
 
   static final String FALLBACK_TRANSITION = "fallback";
+  static final String FACTORY_NAME = "cb";
 
   @Override
   public String getName() {
-    return "cb";
+    return FACTORY_NAME;
   }
 
   @Override

--- a/handler/core/src/main/java/io/knotx/fragments/handler/action/cb/CircuitBreakerActionFactoryOptions.java
+++ b/handler/core/src/main/java/io/knotx/fragments/handler/action/cb/CircuitBreakerActionFactoryOptions.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (C) 2019 Knot.x Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.knotx.fragments.handler.action.cb;
+
+import io.vertx.circuitbreaker.CircuitBreakerOptions;
+import io.vertx.codegen.annotations.DataObject;
+import io.vertx.core.json.JsonObject;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.commons.lang3.StringUtils;
+
+@DataObject(generateConverter = true)
+public class CircuitBreakerActionFactoryOptions {
+
+  /**
+   * Default value of the fallback on failure property.
+   */
+  private static final boolean DEFAULT_FALLBACK_ON_FAILURE = true;
+
+  private static final String DEFAULT_NODE_LOG_LEVEL = "error";
+
+  private static final CircuitBreakerOptions DEFAULT_CIRCUIT_BREAKER_OPTIONS = initCircuitBreakerOptions(
+      new CircuitBreakerOptions());
+
+  private String circuitBreakerName;
+
+  private CircuitBreakerOptions circuitBreakerOptions = DEFAULT_CIRCUIT_BREAKER_OPTIONS;
+
+  private String logLevel = DEFAULT_NODE_LOG_LEVEL;
+
+  /**
+   * Creates a new instance of {@link CircuitBreakerActionFactoryOptions} using the default values.
+   */
+  public CircuitBreakerActionFactoryOptions() {
+    // Empty constructor
+  }
+
+  /**
+   * Creates a new instance of {@link CircuitBreakerActionFactoryOptions} from the given json
+   * object.
+   *
+   * @param json the json object
+   */
+  public CircuitBreakerActionFactoryOptions(JsonObject json) {
+    CircuitBreakerActionFactoryOptionsConverter.fromJson(json, this);
+    this.circuitBreakerOptions = initCircuitBreakerOptions(circuitBreakerOptions);
+  }
+
+  private static CircuitBreakerOptions initCircuitBreakerOptions(CircuitBreakerOptions options) {
+    CircuitBreakerOptions newOptions = new CircuitBreakerOptions(options);
+    newOptions.setFallbackOnFailure(DEFAULT_FALLBACK_ON_FAILURE);
+    return newOptions;
+  }
+
+  /**
+   * @return a json object representing the current configuration.
+   */
+  public JsonObject toJson() {
+    JsonObject json = new JsonObject();
+    CircuitBreakerActionFactoryOptionsConverter.toJson(this, json);
+    return json;
+  }
+
+  /**
+   * @return the unique circuit breaker name.
+   */
+  public String getCircuitBreakerName() {
+    return StringUtils.isNoneBlank(circuitBreakerName) ? circuitBreakerName
+        : RandomStringUtils.random(10, true, false);
+  }
+
+  /**
+   * Sets the circuit breaker name.
+   *
+   * @param circuitBreakerName the circuit breaker name.
+   * @return the current {@link CircuitBreakerActionFactoryOptions} instance
+   */
+  public CircuitBreakerActionFactoryOptions setCircuitBreakerName(String circuitBreakerName) {
+    this.circuitBreakerName = circuitBreakerName;
+    return this;
+  }
+
+  /**
+   * @return the circuit breaker configuration options
+   */
+  public CircuitBreakerOptions getCircuitBreakerOptions() {
+    return circuitBreakerOptions;
+  }
+
+  /**
+   * Sets the circuit breaker configuration options. Note that Knot.x enforce the fallback on error
+   * strategy.
+   *
+   * @param circuitBreakerOptions the circuit breaker name.
+   * @return the current {@link CircuitBreakerActionFactoryOptions} instance
+   */
+  public CircuitBreakerActionFactoryOptions setCircuitBreakerOptions(
+      CircuitBreakerOptions circuitBreakerOptions) {
+    this.circuitBreakerOptions = circuitBreakerOptions;
+    return this;
+  }
+
+  /**
+   * @return the action node log level
+   */
+  public String getLogLevel() {
+    return logLevel;
+  }
+
+  /**
+   * Sets the action node log level.
+   *
+   * @param logLevel the log level.
+   * @return the current {@link CircuitBreakerActionFactoryOptions} instance
+   */
+  public CircuitBreakerActionFactoryOptions setLogLevel(String logLevel) {
+    this.logLevel = logLevel;
+    return this;
+  }
+}

--- a/handler/core/src/main/java/io/knotx/fragments/handler/action/cb/CircuitBreakerActionFactoryOptions.java
+++ b/handler/core/src/main/java/io/knotx/fragments/handler/action/cb/CircuitBreakerActionFactoryOptions.java
@@ -15,10 +15,12 @@
  */
 package io.knotx.fragments.handler.action.cb;
 
+import static io.knotx.fragments.handler.api.actionlog.ActionLogLevel.ERROR;
+
 import io.vertx.circuitbreaker.CircuitBreakerOptions;
 import io.vertx.codegen.annotations.DataObject;
 import io.vertx.core.json.JsonObject;
-import org.apache.commons.lang3.RandomStringUtils;
+import java.util.UUID;
 import org.apache.commons.lang3.StringUtils;
 
 @DataObject(generateConverter = true)
@@ -28,8 +30,6 @@ public class CircuitBreakerActionFactoryOptions {
    * Default value of the fallback on failure property.
    */
   private static final boolean DEFAULT_FALLBACK_ON_FAILURE = true;
-
-  private static final String DEFAULT_NODE_LOG_LEVEL = "error";
 
   private static final CircuitBreakerOptions DEFAULT_CIRCUIT_BREAKER_OPTIONS = initCircuitBreakerOptions(
       new CircuitBreakerOptions());

--- a/handler/core/src/main/java/io/knotx/fragments/handler/action/cb/CircuitBreakerActionFactoryOptions.java
+++ b/handler/core/src/main/java/io/knotx/fragments/handler/action/cb/CircuitBreakerActionFactoryOptions.java
@@ -38,7 +38,7 @@ public class CircuitBreakerActionFactoryOptions {
 
   private CircuitBreakerOptions circuitBreakerOptions = DEFAULT_CIRCUIT_BREAKER_OPTIONS;
 
-  private String logLevel = DEFAULT_NODE_LOG_LEVEL;
+  private String logLevel = ERROR.getLevel();
 
   /**
    * Creates a new instance of {@link CircuitBreakerActionFactoryOptions} using the default values.
@@ -78,7 +78,7 @@ public class CircuitBreakerActionFactoryOptions {
    */
   public String getCircuitBreakerName() {
     return StringUtils.isNoneBlank(circuitBreakerName) ? circuitBreakerName
-        : RandomStringUtils.random(10, true, false);
+        : UUID.randomUUID().toString();
   }
 
   /**

--- a/handler/core/src/main/java/io/knotx/fragments/handler/exception/DoActionExecuteException.java
+++ b/handler/core/src/main/java/io/knotx/fragments/handler/exception/DoActionExecuteException.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2019 Knot.x Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * The code comes from https://github.com/tomaszmichalak/vertx-rx-map-reduce.
+ */
+package io.knotx.fragments.handler.exception;
+
+public class DoActionExecuteException extends RuntimeException {
+
+  public DoActionExecuteException(String message) {
+    super(message);
+  }
+}

--- a/handler/core/src/main/java/io/knotx/fragments/task/factory/DefaultTaskFactoryConfig.java
+++ b/handler/core/src/main/java/io/knotx/fragments/task/factory/DefaultTaskFactoryConfig.java
@@ -15,15 +15,17 @@
  */
 package io.knotx.fragments.task.factory;
 
-import io.knotx.fragments.task.factory.node.NodeFactoryOptions;
-import io.vertx.codegen.annotations.DataObject;
-import io.vertx.core.json.JsonObject;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+
 import org.apache.commons.lang3.StringUtils;
+
+import io.knotx.fragments.task.factory.node.NodeFactoryOptions;
+import io.vertx.codegen.annotations.DataObject;
+import io.vertx.core.json.JsonObject;
 
 /**
  * Default Task Factory config model.
@@ -51,19 +53,17 @@ public class DefaultTaskFactoryConfig {
   }
 
   private void initNodeLogLevel(JsonObject json) {
-    LogLevelConfig globalLogLevel = new LogLevelConfig(json);
-    if (StringUtils.isNotBlank(logLevel)) {
-      nodeFactories.forEach(nodeFactoryOptions ->
-          override(nodeFactoryOptions.getConfig(), globalLogLevel.getLogLevel()));
-    }
+    LogLevelConfig globalLogLevel =
+        StringUtils.isBlank(logLevel) ? new LogLevelConfig() : new LogLevelConfig(json);
+    nodeFactories.forEach(nodeFactoryOptions ->
+        override(nodeFactoryOptions.getConfig(), globalLogLevel.getLogLevel()));
+
   }
 
   private void override(JsonObject json, String globalLogLevel) {
-    if (!StringUtils.isBlank(globalLogLevel)) {
-      LogLevelConfig logLevelConfig = new LogLevelConfig(json);
-      if (StringUtils.isBlank(logLevelConfig.getLogLevel())) {
-        json.mergeIn(logLevelConfig.setLogLevel(globalLogLevel).toJson());
-      }
+    LogLevelConfig logLevelConfig = new LogLevelConfig(json);
+    if (StringUtils.isBlank(logLevelConfig.getLogLevel())) {
+      json.mergeIn(logLevelConfig.setLogLevel(globalLogLevel).toJson());
     }
   }
 

--- a/handler/core/src/main/java/io/knotx/fragments/task/factory/LogLevelConfig.java
+++ b/handler/core/src/main/java/io/knotx/fragments/task/factory/LogLevelConfig.java
@@ -15,6 +15,8 @@
  */
 package io.knotx.fragments.task.factory;
 
+import static io.knotx.fragments.handler.api.actionlog.ActionLogLevel.ERROR;
+
 import io.vertx.codegen.annotations.DataObject;
 import io.vertx.core.json.JsonObject;
 import java.util.Objects;
@@ -24,6 +26,10 @@ import org.apache.commons.lang3.StringUtils;
 public class LogLevelConfig {
 
   private String logLevel;
+
+  public LogLevelConfig() {
+    logLevel = ERROR.getLevel();
+  }
 
   public LogLevelConfig(JsonObject json) {
     LogLevelConfigConverter.fromJson(json, this);

--- a/handler/core/src/main/resources/META-INF/services/io.knotx.fragments.handler.api.ActionFactory
+++ b/handler/core/src/main/resources/META-INF/services/io.knotx.fragments.handler.api.ActionFactory
@@ -13,7 +13,7 @@
 #  limitations under the License.
 
 # behaviours
-io.knotx.fragments.handler.action.CircuitBreakerActionFactory
+io.knotx.fragments.handler.action.cb.CircuitBreakerActionFactory
 io.knotx.fragments.handler.action.InMemoryCacheActionFactory
 
 # pre-defined actions

--- a/handler/core/src/test/java/io/knotx/fragments/handler/action/CircuitBreakerActionTest.java
+++ b/handler/core/src/test/java/io/knotx/fragments/handler/action/CircuitBreakerActionTest.java
@@ -101,7 +101,7 @@ class CircuitBreakerActionTest {
               .verify(() -> {
                 //then
                 ActionLog actionLog = new ActionLog(result.getNodeLog());
-                List<ActionInvocationLog> doActionsLogs = actionLog.getDoActionLogs();
+                List<ActionInvocationLog> doActionsLogs = actionLog.getInvocationLogs();
                 String invocationCount = actionLog.getLogs().getString("invocationCount");
 
                 Assertions.assertEquals(1, doActionsLogs.size());
@@ -205,7 +205,7 @@ class CircuitBreakerActionTest {
 
                 ActionLog actionLog = new ActionLog(result.getNodeLog());
                 String fallback = actionLog.getLogs().getString("fallback");
-                List<ActionInvocationLog> doActionsLogs = actionLog.getDoActionLogs();
+                List<ActionInvocationLog> doActionsLogs = actionLog.getInvocationLogs();
 
                 Assertions.assertEquals(1, doActionsLogs.size());
                 ActionInvocationLog invocationLog = doActionsLogs.get(0);
@@ -243,7 +243,7 @@ class CircuitBreakerActionTest {
                 Assertions.assertEquals(FALLBACK_TRANSITION, result.result().getTransition());
 
                 ActionLog actionLog = new ActionLog(result.result().getNodeLog());
-                List<ActionInvocationLog> doActionsLogs = actionLog.getDoActionLogs();
+                List<ActionInvocationLog> doActionsLogs = actionLog.getInvocationLogs();
                 Assertions.assertEquals(1, doActionsLogs.size());
                 ActionInvocationLog invocationLog = doActionsLogs.get(0);
 
@@ -313,7 +313,7 @@ class CircuitBreakerActionTest {
             Assertions.assertEquals(SUCCESS_TRANSITION, fragmentResult.getTransition());
 
             ActionLog actionLog = new ActionLog(fragmentResult.getNodeLog());
-            List<ActionInvocationLog> doActionsLogs = actionLog.getDoActionLogs();
+            List<ActionInvocationLog> doActionsLogs = actionLog.getInvocationLogs();
             String invocationCount = actionLog.getLogs().getString("invocationCount");
 
             Assertions.assertEquals(2, doActionsLogs.size());
@@ -345,7 +345,7 @@ class CircuitBreakerActionTest {
             Assertions.assertEquals(SUCCESS_TRANSITION, fragmentResult.getTransition());
 
             ActionLog actionLog = new ActionLog(fragmentResult.getNodeLog());
-            List<ActionInvocationLog> doActionsLogs = actionLog.getDoActionLogs();
+            List<ActionInvocationLog> doActionsLogs = actionLog.getInvocationLogs();
             String invocationCount = actionLog.getLogs().getString("invocationCount");
 
             Assertions.assertEquals(2, doActionsLogs.size());
@@ -377,7 +377,7 @@ class CircuitBreakerActionTest {
             Assertions.assertEquals(FALLBACK_TRANSITION, fragmentResult.getTransition());
 
             ActionLog actionLog = new ActionLog(fragmentResult.getNodeLog());
-            List<ActionInvocationLog> doActionsLogs = actionLog.getDoActionLogs();
+            List<ActionInvocationLog> doActionsLogs = actionLog.getInvocationLogs();
             String invocationCount = actionLog.getLogs().getString("invocationCount");
 
             Assertions.assertEquals(2, doActionsLogs.size());
@@ -408,7 +408,7 @@ class CircuitBreakerActionTest {
             Assertions.assertEquals(FALLBACK_TRANSITION, fragmentResult.getTransition());
 
             ActionLog actionLog = new ActionLog(fragmentResult.getNodeLog());
-            List<ActionInvocationLog> doActionsLogs = actionLog.getDoActionLogs();
+            List<ActionInvocationLog> doActionsLogs = actionLog.getInvocationLogs();
             String invocationCount = actionLog.getLogs().getString("invocationCount");
 
             Assertions.assertEquals(1, doActionsLogs.size());
@@ -435,7 +435,7 @@ class CircuitBreakerActionTest {
             Assertions.assertEquals(FALLBACK_TRANSITION, fragmentResult.getTransition());
 
             ActionLog actionLog = new ActionLog(fragmentResult.getNodeLog());
-            List<ActionInvocationLog> doActionsLogs = actionLog.getDoActionLogs();
+            List<ActionInvocationLog> doActionsLogs = actionLog.getInvocationLogs();
             String invocationCount = actionLog.getLogs().getString("invocationCount");
 
             Assertions.assertEquals(1, doActionsLogs.size());
@@ -462,7 +462,7 @@ class CircuitBreakerActionTest {
             Assertions.assertEquals(FALLBACK_TRANSITION, fragmentResult.getTransition());
 
             ActionLog actionLog = new ActionLog(fragmentResult.getNodeLog());
-            List<ActionInvocationLog> doActionsLogs = actionLog.getDoActionLogs();
+            List<ActionInvocationLog> doActionsLogs = actionLog.getInvocationLogs();
             String invocationCount = actionLog.getLogs().getString("invocationCount");
 
             Assertions.assertEquals(0, doActionsLogs.size());
@@ -486,7 +486,7 @@ class CircuitBreakerActionTest {
             Assertions.assertEquals(FALLBACK_TRANSITION, fragmentResult.getTransition());
 
             ActionLog actionLog = new ActionLog(fragmentResult.getNodeLog());
-            List<ActionInvocationLog> doActionsLogs = actionLog.getDoActionLogs();
+            List<ActionInvocationLog> doActionsLogs = actionLog.getInvocationLogs();
             String invocationCount = actionLog.getLogs().getString("invocationCount");
 
             Assertions.assertEquals(0, doActionsLogs.size());

--- a/handler/core/src/test/java/io/knotx/fragments/handler/action/CircuitBreakerActionTest.java
+++ b/handler/core/src/test/java/io/knotx/fragments/handler/action/CircuitBreakerActionTest.java
@@ -18,10 +18,16 @@
 package io.knotx.fragments.handler.action;
 
 import static io.knotx.fragments.handler.action.CircuitBreakerActionFactory.FALLBACK_TRANSITION;
+import static io.knotx.fragments.handler.api.actionlog.ActionLogLevel.INFO;
+import static io.knotx.fragments.handler.api.domain.FragmentResult.ERROR_TRANSITION;
 import static io.knotx.fragments.handler.api.domain.FragmentResult.SUCCESS_TRANSITION;
 
 import io.knotx.fragments.api.Fragment;
 import io.knotx.fragments.handler.action.CircuitBreakerActionFactory.CircuitBreakerAction;
+import io.knotx.fragments.handler.api.Action;
+import io.knotx.fragments.handler.api.actionlog.ActionInvocationLog;
+import io.knotx.fragments.handler.api.actionlog.ActionLog;
+import io.knotx.fragments.handler.api.actionlog.ActionLogger;
 import io.knotx.fragments.handler.api.domain.FragmentContext;
 import io.knotx.fragments.handler.api.domain.FragmentResult;
 import io.knotx.server.api.context.ClientRequest;
@@ -32,10 +38,14 @@ import io.vertx.circuitbreaker.impl.CircuitBreakerImpl;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
+import io.vertx.core.eventbus.ReplyException;
+import io.vertx.core.eventbus.ReplyFailure;
 import io.vertx.core.json.JsonObject;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import io.vertx.rxjava.core.Future;
+
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
@@ -49,20 +59,35 @@ class CircuitBreakerActionTest {
   private static final int TIMEOUT_IN_MS = 500;
 
   @Test
-  @DisplayName("Expect operation ends when doAction ends on time.")
+  @DisplayName("Expect operation ends when doAction ends on time. Action logs from doAction present.")
   void expectOperationEnds(VertxTestContext testContext, Vertx vertx) throws Throwable {
     // given
     CircuitBreakerOptions options = new CircuitBreakerOptions().setTimeout(TIMEOUT_IN_MS);
     CircuitBreaker circuitBreaker = new CircuitBreakerImpl("name", vertx, options);
 
     CircuitBreakerAction tested = new CircuitBreakerAction(circuitBreaker,
-        CircuitBreakerActionTest::apply);
+        CircuitBreakerActionTest::applySuccess,
+        "tested", INFO, ERROR_TRANSITION);
 
     // when
     tested.apply(new FragmentContext(FRAGMENT, new ClientRequest()),
         testContext.succeeding(result -> {
           testContext
-              .verify(() -> Assertions.assertEquals(SUCCESS_TRANSITION, result.getTransition()));
+              .verify(() -> {
+                Assertions.assertEquals(SUCCESS_TRANSITION, result.getTransition());
+
+                ActionLog actionLog = new ActionLog(result.getNodeLog());
+                List<ActionInvocationLog> doActionsLogs = actionLog.getDoActionLogs();
+                String invocationCount = actionLog.getLogs().getString("invocationCount");
+
+                Assertions.assertEquals(1, doActionsLogs.size());
+                ActionInvocationLog invocationLog = doActionsLogs.get(0);
+
+                Assertions.assertTrue(invocationLog.isSuccess());
+                Assertions.assertNotNull(invocationLog.getDuration());
+                Assertions.assertEquals("1", invocationCount);
+                Assertions.assertEquals("action", invocationLog.getDoActionLog().getAlias());
+              });
           testContext.completeNow();
         }));
 
@@ -78,22 +103,28 @@ class CircuitBreakerActionTest {
   void expectFallback(VertxTestContext testContext, Vertx vertx) throws Throwable {
     // given
     CircuitBreakerOptions options = new CircuitBreakerOptions()
-        .setTimeout(TIMEOUT_IN_MS).setFallbackOnFailure(true);
+        .setTimeout(TIMEOUT_IN_MS).setFallbackOnFailure(true).setMaxRetries(2);
     CircuitBreaker circuitBreaker = new CircuitBreakerImpl("name", vertx, options);
-
     CircuitBreakerAction tested = new CircuitBreakerAction(circuitBreaker,
-        (fragmentContext, resultHandler) ->
-            vertx.setTimer(1000,
-                l ->
-                    Future.succeededFuture(
-                        new FragmentResult(fragmentContext.getFragment(), SUCCESS_TRANSITION)
-                    ).setHandler(resultHandler)));
+        CircuitBreakerActionTest.applyTimeout(vertx),
+        "tested", INFO, ERROR_TRANSITION);
+
 
     // when
     tested.apply(new FragmentContext(FRAGMENT, new ClientRequest()),
         testContext.succeeding(result -> {
           testContext
-              .verify(() -> Assertions.assertEquals(FALLBACK_TRANSITION, result.getTransition()));
+              .verify(() -> {
+                Assertions.assertEquals(FALLBACK_TRANSITION, result.getTransition());
+
+                ActionLog actionLog = new ActionLog(result.getNodeLog());
+                String fallback = actionLog.getLogs().getString("fallback");
+                String invocationCount = actionLog.getLogs().getString("invocationCount");
+
+                Assertions.assertNotNull(fallback);
+                Assertions.assertTrue(fallback.contains("TimeoutException"));
+                Assertions.assertEquals("3", invocationCount);
+              });
           testContext.completeNow();
         }));
 
@@ -112,12 +143,8 @@ class CircuitBreakerActionTest {
     CircuitBreaker circuitBreaker = new CircuitBreakerImpl("name", vertx, options);
 
     CircuitBreakerAction tested = new CircuitBreakerAction(circuitBreaker,
-        (fragmentContext, resultHandler) ->
-            vertx.setTimer(1000,
-                l ->
-                    Future.succeededFuture(
-                        new FragmentResult(fragmentContext.getFragment(), SUCCESS_TRANSITION)
-                    ).setHandler(resultHandler)));
+        CircuitBreakerActionTest.applyTimeout(vertx),
+        "tested", INFO, ERROR_TRANSITION);
 
     // when
     tested.apply(new FragmentContext(FRAGMENT, new ClientRequest()),
@@ -134,10 +161,109 @@ class CircuitBreakerActionTest {
     }
   }
 
-  private static void apply(FragmentContext fragmentContext,
+  @Test
+  @DisplayName("Expect fallback transition when doAction ends up _error transition and circuit breaker is in fallback mode.")
+  void expectFallbackWhenDoActionEndsErrorTransition(VertxTestContext testContext, Vertx vertx) throws Throwable {
+    // given
+    CircuitBreakerOptions options = new CircuitBreakerOptions().setFallbackOnFailure(true);
+    CircuitBreaker circuitBreaker = new CircuitBreakerImpl("name", vertx, options);
+
+    CircuitBreakerAction tested = new CircuitBreakerAction(circuitBreaker,
+        CircuitBreakerActionTest::applyErrorTransition,"tested", INFO, ERROR_TRANSITION);
+
+    // when
+    tested.apply(new FragmentContext(FRAGMENT, new ClientRequest()),
+        testContext.succeeding(result -> {
+          testContext
+              .verify(() -> {
+                Assertions.assertEquals(FALLBACK_TRANSITION, result.getTransition());
+
+                ActionLog actionLog = new ActionLog(result.getNodeLog());
+                String fallback = actionLog.getLogs().getString("fallback");
+                List<ActionInvocationLog> doActionsLogs = actionLog.getDoActionLogs();
+
+                Assertions.assertEquals(1, doActionsLogs.size());
+                ActionInvocationLog invocationLog = doActionsLogs.get(0);
+
+                Assertions.assertFalse(invocationLog.isSuccess());
+                Assertions.assertNotNull(fallback);
+                Assertions.assertTrue(fallback.contains("DoActionExecuteException"));
+              });
+          testContext.completeNow();
+        }));
+
+    //then
+    Assertions.assertTrue(testContext.awaitCompletion(5, TimeUnit.SECONDS));
+    if (testContext.failed()) {
+      throw testContext.causeOfFailure();
+    }
+  }
+
+  @Test
+  @DisplayName("Expect fallback transition when doAction throws exception and circuit breaker is in fallback mode.")
+  void expectTBla(VertxTestContext testContext, Vertx vertx) throws Throwable {
+    // given
+    CircuitBreakerOptions options = new CircuitBreakerOptions().setFallbackOnFailure(true);
+    CircuitBreaker circuitBreaker = new CircuitBreakerImpl("name", vertx, options);
+
+    CircuitBreakerAction tested = new CircuitBreakerAction(circuitBreaker,
+        CircuitBreakerActionTest::applyException,
+        "tested", INFO, ERROR_TRANSITION);
+
+    // when
+    tested.apply(new FragmentContext(FRAGMENT, new ClientRequest()),
+        testContext.succeeding(result -> {
+          testContext
+              .verify(() ->{
+                Assertions.assertEquals(FALLBACK_TRANSITION, result.getTransition());
+
+                ActionLog actionLog = new ActionLog(result.getNodeLog());
+                String fallback = actionLog.getLogs().getString("fallback");
+                String invocationCount = actionLog.getLogs().getString("invocationCount");
+
+                Assertions.assertNotNull(fallback);
+                Assertions.assertTrue(fallback.contains("ReplyException"));
+                Assertions.assertEquals("1", invocationCount);
+                  });
+          testContext.completeNow();
+        }));
+
+    //then
+    Assertions.assertTrue(testContext.awaitCompletion(5, TimeUnit.SECONDS));
+    if (testContext.failed()) {
+      throw testContext.causeOfFailure();
+    }
+  }
+
+  private static void applySuccess(FragmentContext fragmentContext,
       Handler<AsyncResult<FragmentResult>> resultHandler) {
-    Future.succeededFuture(new FragmentResult(fragmentContext.getFragment(), SUCCESS_TRANSITION))
+    ActionLogger actionLogger = ActionLogger.create("action", INFO);
+    actionLogger.info("info", "success");
+    Future.succeededFuture(new FragmentResult(fragmentContext.getFragment(), SUCCESS_TRANSITION,
+        actionLogger.toLog().toJson()))
         .setHandler(resultHandler);
   }
 
+  private static void applyErrorTransition(FragmentContext fragmentContext,
+      Handler<AsyncResult<FragmentResult>> resultHandler) {
+    ActionLogger actionLogger = ActionLogger.create("action", INFO);
+    actionLogger.info("info", "error");
+    Future.succeededFuture(new FragmentResult(fragmentContext.getFragment(), ERROR_TRANSITION,
+        actionLogger.toLog().toJson()))
+        .setHandler(resultHandler);
+  }
+
+  private static void applyException(FragmentContext fragmentContext,
+      Handler<AsyncResult<FragmentResult>> resultHandler) {
+    throw new ReplyException(ReplyFailure.RECIPIENT_FAILURE, "Error from action");
+  }
+
+  private static Action applyTimeout(Vertx vertx) {
+    return (fragmentContext, resultHandler) ->
+        vertx.setTimer(1000,
+            l ->
+                Future.succeededFuture(
+                    new FragmentResult(fragmentContext.getFragment(), SUCCESS_TRANSITION)
+                ).setHandler(resultHandler));
+  }
 }

--- a/handler/core/src/test/java/io/knotx/fragments/handler/action/CircuitBreakerActionTest.java
+++ b/handler/core/src/test/java/io/knotx/fragments/handler/action/CircuitBreakerActionTest.java
@@ -67,8 +67,7 @@ class CircuitBreakerActionTest {
     CircuitBreaker circuitBreaker = new CircuitBreakerImpl("name", vertx, options);
 
     CircuitBreakerAction tested = new CircuitBreakerAction(circuitBreaker,
-        CircuitBreakerDoActions.applySuccessDelay(vertx),
-        "tested", INFO, ERROR_TRANSITION);
+        CircuitBreakerDoActions.applySuccessDelay(vertx), "tested", INFO);
 
     // when
     tested.apply(new FragmentContext(FRAGMENT, new ClientRequest()),
@@ -96,8 +95,7 @@ class CircuitBreakerActionTest {
     CircuitBreaker circuitBreaker = new CircuitBreakerImpl("name", vertx, options);
 
     CircuitBreakerAction tested = new CircuitBreakerAction(circuitBreaker,
-        CircuitBreakerDoActions::applySuccessWithActionLogs,
-        "tested", INFO, ERROR_TRANSITION);
+        CircuitBreakerDoActions::applySuccessWithActionLogs, "tested", INFO);
 
     // when
     tested.apply(new FragmentContext(FRAGMENT, new ClientRequest()),
@@ -137,7 +135,7 @@ class CircuitBreakerActionTest {
     CircuitBreaker circuitBreaker = new CircuitBreakerImpl("name", vertx, options);
 
     CircuitBreakerAction tested = new CircuitBreakerAction(circuitBreaker,
-        CircuitBreakerDoActions::applyErrorTransition, "tested", INFO, ERROR_TRANSITION);
+        CircuitBreakerDoActions::applyErrorTransition, "tested", INFO);
 
     // when
     tested.apply(new FragmentContext(FRAGMENT, new ClientRequest()),
@@ -177,7 +175,7 @@ class CircuitBreakerActionTest {
     CircuitBreaker circuitBreaker = new CircuitBreakerImpl("name", vertx, options);
 
     CircuitBreakerAction tested = new CircuitBreakerAction(circuitBreaker,
-        CircuitBreakerDoActions::applyFailure, "tested", INFO, ERROR_TRANSITION);
+        CircuitBreakerDoActions::applyFailure, "tested", INFO);
 
     // when
     tested.apply(new FragmentContext(FRAGMENT, new ClientRequest()),
@@ -218,8 +216,7 @@ class CircuitBreakerActionTest {
         .setTimeout(TIMEOUT_IN_MS);
     CircuitBreaker circuitBreaker = new CircuitBreakerImpl("name", vertx, options);
     CircuitBreakerAction tested = new CircuitBreakerAction(circuitBreaker,
-        CircuitBreakerDoActions.applySuccessDelay(vertx),
-        "tested", INFO, ERROR_TRANSITION);
+        CircuitBreakerDoActions.applySuccessDelay(vertx), "tested", INFO);
 
     // when
     tested.apply(new FragmentContext(FRAGMENT, new ClientRequest()),
@@ -256,8 +253,7 @@ class CircuitBreakerActionTest {
     CircuitBreaker circuitBreaker = new CircuitBreakerImpl("name", vertx, options);
 
     CircuitBreakerAction tested = new CircuitBreakerAction(circuitBreaker,
-        CircuitBreakerDoActions::applyException,
-        "tested", INFO, ERROR_TRANSITION);
+        CircuitBreakerDoActions::applyException, "tested", INFO);
 
     // when
     tested.apply(new FragmentContext(FRAGMENT, new ClientRequest()),
@@ -521,8 +517,8 @@ class CircuitBreakerActionTest {
 
     CircuitBreakerAction tested = new CircuitBreakerAction(circuitBreaker,
         CircuitBreakerDoActions
-            .applyOneAfterAnother(firstInvocationBehaviour, secondInvocationBehaviour),
-        "tested", INFO, ERROR_TRANSITION);
+            .applyOneAfterAnother(firstInvocationBehaviour, secondInvocationBehaviour), "tested",
+        INFO);
 
     // when
     tested.apply(new FragmentContext(FRAGMENT, new ClientRequest()), handler);

--- a/handler/core/src/test/java/io/knotx/fragments/handler/action/CircuitBreakerDoActions.java
+++ b/handler/core/src/test/java/io/knotx/fragments/handler/action/CircuitBreakerDoActions.java
@@ -1,0 +1,84 @@
+package io.knotx.fragments.handler.action;
+
+import static io.knotx.fragments.handler.api.actionlog.ActionLogLevel.INFO;
+import static io.knotx.fragments.handler.api.domain.FragmentResult.ERROR_TRANSITION;
+import static io.knotx.fragments.handler.api.domain.FragmentResult.SUCCESS_TRANSITION;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import io.knotx.fragments.handler.api.Action;
+import io.knotx.fragments.handler.api.actionlog.ActionLogger;
+import io.knotx.fragments.handler.api.domain.FragmentContext;
+import io.knotx.fragments.handler.api.domain.FragmentResult;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.core.eventbus.ReplyException;
+import io.vertx.core.eventbus.ReplyFailure;
+import io.vertx.rxjava.core.Future;
+
+class CircuitBreakerDoActions {
+
+  static void applySuccess(FragmentContext fragmentContext,
+      Handler<AsyncResult<FragmentResult>> resultHandler) {
+    Future.succeededFuture(new FragmentResult(fragmentContext.getFragment(), SUCCESS_TRANSITION))
+        .setHandler(resultHandler);
+  }
+
+  static void applySuccessWithActionLogs(FragmentContext fragmentContext,
+      Handler<AsyncResult<FragmentResult>> resultHandler) {
+    ActionLogger actionLogger = ActionLogger.create("action", INFO);
+    actionLogger.info("info", "success");
+    Future.succeededFuture(new FragmentResult(fragmentContext.getFragment(), SUCCESS_TRANSITION,
+        actionLogger.toLog().toJson()))
+        .setHandler(resultHandler);
+  }
+
+  static void applyErrorTransition(FragmentContext fragmentContext,
+      Handler<AsyncResult<FragmentResult>> resultHandler) {
+    ActionLogger actionLogger = ActionLogger.create("action", INFO);
+    actionLogger.info("info", "error");
+    Future.succeededFuture(new FragmentResult(fragmentContext.getFragment(), ERROR_TRANSITION,
+        actionLogger.toLog().toJson()))
+        .setHandler(resultHandler);
+  }
+
+  static void applyFailure(FragmentContext fragmentContext,
+      Handler<AsyncResult<FragmentResult>> resultHandler) {
+    ActionLogger actionLogger = ActionLogger.create("action", INFO);
+    actionLogger.info("info", "error");
+    Future.<FragmentResult>failedFuture(new IllegalStateException()).setHandler(resultHandler);
+  }
+
+  static void applyException(FragmentContext fragmentContext,
+      Handler<AsyncResult<FragmentResult>> resultHandler) {
+    throw new ReplyException(ReplyFailure.RECIPIENT_FAILURE, "Error from action");
+  }
+
+  static Action applyOneAfterAnother(Action first, Action second) {
+    AtomicInteger counter = new AtomicInteger(0);
+    return (fragmentContext, resultHandler) -> {
+      applySecondAfterFirst(fragmentContext, resultHandler, first, second,
+          counter.incrementAndGet());
+    };
+  }
+
+  static void applySecondAfterFirst(FragmentContext fragmentContext,
+      Handler<AsyncResult<FragmentResult>> resultHandler, Action first, Action second,
+      Integer counter) {
+    if (counter == 1) {
+      first.apply(fragmentContext, resultHandler);
+    } else {
+      second.apply(fragmentContext, resultHandler);
+    }
+  }
+
+  static Action applyTimeout(Vertx vertx) {
+    return (fragmentContext, resultHandler) ->
+        vertx.setTimer(1000,
+            l ->
+                Future.succeededFuture(
+                    new FragmentResult(fragmentContext.getFragment(), SUCCESS_TRANSITION)
+                ).setHandler(resultHandler));
+  }
+}

--- a/handler/core/src/test/java/io/knotx/fragments/handler/action/CircuitBreakerDoActions.java
+++ b/handler/core/src/test/java/io/knotx/fragments/handler/action/CircuitBreakerDoActions.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2019 Knot.x Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * The code comes from https://github.com/tomaszmichalak/vertx-rx-map-reduce.
+ */
 package io.knotx.fragments.handler.action;
 
 import static io.knotx.fragments.handler.api.actionlog.ActionLogLevel.INFO;

--- a/handler/core/src/test/java/io/knotx/fragments/handler/action/CircuitBreakerDoActions.java
+++ b/handler/core/src/test/java/io/knotx/fragments/handler/action/CircuitBreakerDoActions.java
@@ -75,7 +75,7 @@ class CircuitBreakerDoActions {
 
   static Action applyTimeout(Vertx vertx) {
     return (fragmentContext, resultHandler) ->
-        vertx.setTimer(1000,
+        vertx.setTimer(1500,
             l ->
                 Future.succeededFuture(
                     new FragmentResult(fragmentContext.getFragment(), SUCCESS_TRANSITION)

--- a/handler/core/src/test/java/io/knotx/fragments/handler/action/CircuitBreakerDoActions.java
+++ b/handler/core/src/test/java/io/knotx/fragments/handler/action/CircuitBreakerDoActions.java
@@ -90,9 +90,12 @@ class CircuitBreakerDoActions {
     }
   }
 
-  static Action applyTimeout(Vertx vertx) {
+  static Action applySuccessDelay(Vertx vertx) {
+    return applySuccessDelay(vertx, 1500);
+  }
+  static Action applySuccessDelay(Vertx vertx, int delay) {
     return (fragmentContext, resultHandler) ->
-        vertx.setTimer(1500,
+        vertx.setTimer(delay,
             l ->
                 Future.succeededFuture(
                     new FragmentResult(fragmentContext.getFragment(), SUCCESS_TRANSITION)

--- a/handler/core/src/test/java/io/knotx/fragments/handler/action/CircuitBreakerDoActions.java
+++ b/handler/core/src/test/java/io/knotx/fragments/handler/action/CircuitBreakerDoActions.java
@@ -63,7 +63,7 @@ class CircuitBreakerDoActions {
   static void applyFailure(FragmentContext fragmentContext,
       Handler<AsyncResult<FragmentResult>> resultHandler) {
     ActionLogger actionLogger = ActionLogger.create("action", INFO);
-    actionLogger.info("info", "error");
+    actionLogger.info("info", "failure");
     Future.<FragmentResult>failedFuture(new IllegalStateException()).setHandler(resultHandler);
   }
 

--- a/handler/core/src/test/java/io/knotx/fragments/handler/action/cb/CircuitBreakerActionFactoryOptionsTest.java
+++ b/handler/core/src/test/java/io/knotx/fragments/handler/action/cb/CircuitBreakerActionFactoryOptionsTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2019 Knot.x Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.knotx.fragments.handler.action.cb;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.vertx.circuitbreaker.CircuitBreakerOptions;
+import io.vertx.core.json.JsonObject;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.commons.util.StringUtils;
+
+class CircuitBreakerActionFactoryOptionsTest {
+
+  @DisplayName("Expect fallback on failure always enabled")
+  @Test
+  void expectFallbackOnFailure() {
+    //given
+    CircuitBreakerOptions options = new CircuitBreakerOptions().setFallbackOnFailure(false);
+    JsonObject json = new CircuitBreakerActionFactoryOptions()
+        .setCircuitBreakerOptions(options).toJson();
+
+    // when
+    CircuitBreakerActionFactoryOptions tested = new CircuitBreakerActionFactoryOptions(json);
+
+    // then
+    assertTrue(tested.getCircuitBreakerOptions().isFallbackOnFailure());
+  }
+
+
+  @DisplayName("Expect random circuit breaker name when not defined.")
+  @Test
+  void expectCircuitBreakerNameNotBlank() {
+    //given
+    JsonObject json = new CircuitBreakerActionFactoryOptions().toJson();
+
+    // when
+    CircuitBreakerActionFactoryOptions tested = new CircuitBreakerActionFactoryOptions(json);
+
+    // then
+    assertNotNull(tested.getCircuitBreakerName());
+    assertTrue(StringUtils.isNotBlank(tested.getCircuitBreakerName()));
+  }
+}

--- a/handler/core/src/test/java/io/knotx/fragments/handler/action/cb/CircuitBreakerActionFactoryTest.java
+++ b/handler/core/src/test/java/io/knotx/fragments/handler/action/cb/CircuitBreakerActionFactoryTest.java
@@ -15,8 +15,8 @@
  */
 package io.knotx.fragments.handler.action.cb;
 
-import static io.knotx.fragments.handler.action.cb.CircuitBreakerActionFactory.CircuitBreakerAction.ERROR_LOG_KEY;
-import static io.knotx.fragments.handler.action.cb.CircuitBreakerActionFactory.CircuitBreakerAction.INVOCATION_COUNT_LOG_KEY;
+import static io.knotx.fragments.handler.action.cb.CircuitBreakerAction.ERROR_LOG_KEY;
+import static io.knotx.fragments.handler.action.cb.CircuitBreakerAction.INVOCATION_COUNT_LOG_KEY;
 import static io.knotx.fragments.handler.action.cb.CircuitBreakerActionFactory.FALLBACK_TRANSITION;
 import static io.knotx.fragments.handler.api.actionlog.ActionLogLevel.INFO;
 import static io.knotx.fragments.handler.api.domain.FragmentResult.SUCCESS_TRANSITION;
@@ -27,7 +27,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.knotx.fragments.api.Fragment;
-import io.knotx.fragments.handler.action.cb.CircuitBreakerActionFactory.CircuitBreakerAction;
 import io.knotx.fragments.handler.api.Action;
 import io.knotx.fragments.handler.api.actionlog.ActionInvocationLog;
 import io.knotx.fragments.handler.api.actionlog.ActionLog;
@@ -64,7 +63,8 @@ class CircuitBreakerActionFactoryTest {
   @DisplayName("Expect factory name is 'cb'.")
   void checkFactoryName() {
     // given
-    assertEquals(CircuitBreakerActionFactory.FACTORY_NAME, new CircuitBreakerActionFactory().getName());
+    assertEquals(CircuitBreakerActionFactory.FACTORY_NAME,
+        new CircuitBreakerActionFactory().getName());
   }
 
   @ParameterizedTest

--- a/handler/core/src/test/java/io/knotx/fragments/handler/action/cb/CircuitBreakerActionFactoryTest.java
+++ b/handler/core/src/test/java/io/knotx/fragments/handler/action/cb/CircuitBreakerActionFactoryTest.java
@@ -119,7 +119,7 @@ class CircuitBreakerActionFactoryTest {
 
   @ParameterizedTest
   @MethodSource("provideSuccessActions")
-  @DisplayName("Expect empty node log when action ends with success.")
+  @DisplayName("Expect empty node log when action ends with success and default log level.")
   void expectEmptyNodeLogWhenSuccess(Action action, VertxTestContext testContext, Vertx vertx)
       throws Throwable {
     // given
@@ -228,7 +228,7 @@ class CircuitBreakerActionFactoryTest {
 
   @ParameterizedTest
   @MethodSource("provideErrorActions")
-  @DisplayName("Expect two invocation logs are added when action and with error error and retry is 1.")
+  @DisplayName("Expect two invocation logs are added when action ends always with error and retry is 1.")
   void expectTwoInvocationLogsWhenErrorAndRetry(Action action, VertxTestContext testContext,
       Vertx vertx)
       throws Throwable {
@@ -489,7 +489,7 @@ class CircuitBreakerActionFactoryTest {
   }
 
   @Test
-  @DisplayName("Expect fallback transition when both calls time out.")
+  @DisplayName("Expect fallback transition when all calls time out.")
   void expectFallbackWhenTimeouts(VertxTestContext testContext, Vertx vertx)
       throws Throwable {
     validateScenario(

--- a/handler/core/src/test/java/io/knotx/fragments/handler/action/cb/CircuitBreakerActionFactoryTest.java
+++ b/handler/core/src/test/java/io/knotx/fragments/handler/action/cb/CircuitBreakerActionFactoryTest.java
@@ -60,6 +60,13 @@ class CircuitBreakerActionFactoryTest {
   private static final Fragment FRAGMENT = new Fragment("type", new JsonObject(), "expectedBody");
   private static final int TIMEOUT_IN_MS = 500;
 
+  @Test
+  @DisplayName("Expect factory name is 'cb'.")
+  void checkFactoryName() {
+    // given
+    assertEquals(CircuitBreakerActionFactory.FACTORY_NAME, new CircuitBreakerActionFactory().getName());
+  }
+
   @ParameterizedTest
   @MethodSource("provideSuccessActions")
   @DisplayName("Expect _success transition when action ends with success.")

--- a/handler/core/src/test/java/io/knotx/fragments/handler/action/cb/CircuitBreakerActionFactoryTest.java
+++ b/handler/core/src/test/java/io/knotx/fragments/handler/action/cb/CircuitBreakerActionFactoryTest.java
@@ -13,13 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.knotx.fragments.handler.action;
+package io.knotx.fragments.handler.action.cb;
 
-import static io.knotx.fragments.handler.action.CircuitBreakerActionFactory.CircuitBreakerAction.ERROR_LOG_KEY;
-import static io.knotx.fragments.handler.action.CircuitBreakerActionFactory.CircuitBreakerAction.INVOCATION_COUNT_LOG_KEY;
-import static io.knotx.fragments.handler.action.CircuitBreakerActionFactory.FALLBACK_TRANSITION;
+import static io.knotx.fragments.handler.action.cb.CircuitBreakerActionFactory.CircuitBreakerAction.ERROR_LOG_KEY;
+import static io.knotx.fragments.handler.action.cb.CircuitBreakerActionFactory.CircuitBreakerAction.INVOCATION_COUNT_LOG_KEY;
+import static io.knotx.fragments.handler.action.cb.CircuitBreakerActionFactory.FALLBACK_TRANSITION;
 import static io.knotx.fragments.handler.api.actionlog.ActionLogLevel.INFO;
-import static io.knotx.fragments.handler.api.domain.FragmentResult.ERROR_TRANSITION;
 import static io.knotx.fragments.handler.api.domain.FragmentResult.SUCCESS_TRANSITION;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -28,12 +27,13 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.knotx.fragments.api.Fragment;
-import io.knotx.fragments.handler.action.CircuitBreakerActionFactory.CircuitBreakerAction;
+import io.knotx.fragments.handler.action.cb.CircuitBreakerActionFactory.CircuitBreakerAction;
 import io.knotx.fragments.handler.api.Action;
 import io.knotx.fragments.handler.api.actionlog.ActionInvocationLog;
 import io.knotx.fragments.handler.api.actionlog.ActionLog;
 import io.knotx.fragments.handler.api.domain.FragmentContext;
 import io.knotx.fragments.handler.api.domain.FragmentResult;
+import io.knotx.fragments.handler.exception.DoActionExecuteException;
 import io.knotx.server.api.context.ClientRequest;
 import io.vertx.circuitbreaker.CircuitBreaker;
 import io.vertx.circuitbreaker.CircuitBreakerOptions;
@@ -47,55 +47,26 @@ import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 @ExtendWith(VertxExtension.class)
-class CircuitBreakerActionTest {
+class CircuitBreakerActionFactoryTest {
 
   private static final Fragment FRAGMENT = new Fragment("type", new JsonObject(), "expectedBody");
   private static final int TIMEOUT_IN_MS = 500;
 
-  @Test
-  @DisplayName("Expect failure with timeout exception when fallback is not enabled and action times out.")
-  void expectFailureWhenFallbackDisabledAndDoActionTimesOut(VertxTestContext testContext,
-      Vertx vertx) throws Throwable {
+  @ParameterizedTest
+  @MethodSource("provideSuccessActions")
+  @DisplayName("Expect _success transition when action ends with success.")
+  void expectSuccessWhenSuccess(Action action, VertxTestContext testContext, Vertx vertx)
+      throws Throwable {
     // given
-    CircuitBreakerOptions options = new CircuitBreakerOptions()
-        .setTimeout(TIMEOUT_IN_MS);
-    CircuitBreaker circuitBreaker = new CircuitBreakerImpl("name", vertx, options);
-
-    CircuitBreakerAction tested = new CircuitBreakerAction(circuitBreaker,
-        CircuitBreakerDoActions.applySuccessDelay(vertx), "tested", INFO);
-
-    // when
-    tested.apply(new FragmentContext(FRAGMENT, new ClientRequest()),
-        testContext.failing(result -> {
-          testContext
-              .verify(() -> {
-                //then
-                assertTrue(result instanceof TimeoutException);
-              });
-          testContext.completeNow();
-        }));
-
-    assertTrue(testContext.awaitCompletion(5, TimeUnit.SECONDS));
-    if (testContext.failed()) {
-      throw testContext.causeOfFailure();
-    }
-  }
-
-  @Test
-  @DisplayName("Expect _success transition when action ends with _success transition.")
-  void expectSuccessWhenSuccess(VertxTestContext testContext, Vertx vertx) throws Throwable {
-    // given
-    CircuitBreakerOptions options = new CircuitBreakerOptions()
-        .setFallbackOnFailure(true);
-    CircuitBreaker circuitBreaker = new CircuitBreakerImpl("name", vertx, options);
-
-    CircuitBreakerAction tested = new CircuitBreakerAction(circuitBreaker,
-        CircuitBreakerDoActions::applySuccessWithActionLogs, "tested", INFO);
+    Action tested = newActionInstance(action, vertx);
 
     // when
     tested.apply(new FragmentContext(FRAGMENT, new ClientRequest()),
@@ -104,18 +75,6 @@ class CircuitBreakerActionTest {
               .verify(() -> {
                 //then
                 assertEquals(SUCCESS_TRANSITION, result.getTransition());
-
-                ActionLog actionLog = new ActionLog(result.getNodeLog());
-                List<ActionInvocationLog> doActionsLogs = actionLog.getInvocationLogs();
-                String invocationCount = actionLog.getLogs().getString(INVOCATION_COUNT_LOG_KEY);
-
-                assertEquals(1, doActionsLogs.size());
-                ActionInvocationLog invocationLog = doActionsLogs.get(0);
-
-                assertTrue(invocationLog.isSuccess());
-                assertNotNull(invocationLog.getDuration());
-                assertEquals("1", invocationCount);
-                assertEquals("action", invocationLog.getDoActionLog().getAlias());
               });
           testContext.completeNow();
         }));
@@ -126,16 +85,13 @@ class CircuitBreakerActionTest {
     }
   }
 
-  @Test
-  @DisplayName("Expect fallback transition when action ends with _error transition.")
-  void expectFallbackWhenError(VertxTestContext testContext, Vertx vertx)
+  @ParameterizedTest
+  @MethodSource("provideErrorActionsAndTimeout")
+  @DisplayName("Expect fallback transition when action ends with error.")
+  void expectFallbackWhenError(Action action, VertxTestContext testContext, Vertx vertx)
       throws Throwable {
     // given
-    CircuitBreakerOptions options = new CircuitBreakerOptions().setFallbackOnFailure(true);
-    CircuitBreaker circuitBreaker = new CircuitBreakerImpl("name", vertx, options);
-
-    CircuitBreakerAction tested = new CircuitBreakerAction(circuitBreaker,
-        CircuitBreakerDoActions::applyErrorTransition, "tested", INFO);
+    Action tested = newActionInstance(action, vertx);
 
     // when
     tested.apply(new FragmentContext(FRAGMENT, new ClientRequest()),
@@ -144,17 +100,143 @@ class CircuitBreakerActionTest {
               .verify(() -> {
                 //then
                 assertEquals(FALLBACK_TRANSITION, result.getTransition());
+              });
+          testContext.completeNow();
+        }));
 
+    assertTrue(testContext.awaitCompletion(5, TimeUnit.SECONDS));
+    if (testContext.failed()) {
+      throw testContext.causeOfFailure();
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideSuccessActions")
+  @DisplayName("Expect empty node log when action ends with success.")
+  void expectEmptyNodeLogWhenSuccess(Action action, VertxTestContext testContext, Vertx vertx)
+      throws Throwable {
+    // given
+    Action tested = newActionInstance(action, vertx);
+
+    // when
+    tested.apply(new FragmentContext(FRAGMENT, new ClientRequest()),
+        testContext.succeeding(result -> {
+          testContext
+              .verify(() -> {
+                //then
                 ActionLog actionLog = new ActionLog(result.getNodeLog());
-                String errorMessage = actionLog.getLogs().getString(ERROR_LOG_KEY);
-                List<ActionInvocationLog> doActionsLogs = actionLog.getInvocationLogs();
+                assertTrue(actionLog.getLogs().isEmpty());
+                assertTrue(actionLog.getInvocationLogs().isEmpty());
+              });
+          testContext.completeNow();
+        }));
 
-                assertEquals(1, doActionsLogs.size());
-                ActionInvocationLog invocationLog = doActionsLogs.get(0);
-                assertFalse(invocationLog.isSuccess());
-                assertNotNull(invocationLog.getDoActionLog());
-                assertNotNull(errorMessage);
-                assertTrue(errorMessage.contains("DoActionExecuteException"));
+    assertTrue(testContext.awaitCompletion(5, TimeUnit.SECONDS));
+    if (testContext.failed()) {
+      throw testContext.causeOfFailure();
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideAllActions")
+  @DisplayName("Expect invocation count when log level is info.")
+  void expectInvocationCountWhenInfo(Action action, VertxTestContext testContext, Vertx vertx)
+      throws Throwable {
+    // given
+    Action tested = newInstanceWithInfo(action, vertx);
+
+    // when
+    tested.apply(new FragmentContext(FRAGMENT, new ClientRequest()),
+        testContext.succeeding(result -> {
+          testContext
+              .verify(() -> {
+                //then
+                ActionLog actionLog = new ActionLog(result.getNodeLog());
+                assertEquals("1", actionLog.getLogs().getString(INVOCATION_COUNT_LOG_KEY));
+              });
+          testContext.completeNow();
+        }));
+
+    assertTrue(testContext.awaitCompletion(5, TimeUnit.SECONDS));
+    if (testContext.failed()) {
+      throw testContext.causeOfFailure();
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideSuccessActions")
+  @DisplayName("Expect success invocation log is added when action ends with success and log level is info.")
+  void expectSuccessInvocationLogWhenSuccessAndInfo(Action action, VertxTestContext testContext,
+      Vertx vertx)
+      throws Throwable {
+    // given
+    Action tested = newInstanceWithInfo(action, vertx);
+
+    // when
+    tested.apply(new FragmentContext(FRAGMENT, new ClientRequest()),
+        testContext.succeeding(result -> {
+          testContext
+              .verify(() -> {
+                //then
+                ActionLog actionLog = new ActionLog(result.getNodeLog());
+                assertEquals(1, actionLog.getInvocationLogs().size());
+                assertTrue(actionLog.getInvocationLogs().iterator().next().isSuccess());
+              });
+          testContext.completeNow();
+        }));
+
+    assertTrue(testContext.awaitCompletion(5, TimeUnit.SECONDS));
+    if (testContext.failed()) {
+      throw testContext.causeOfFailure();
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideErrorActions")
+  @DisplayName("Expect error invocation log is added when action ends with error.")
+  void expectErrorInvocationLogWhenErrorAndInfo(Action action, VertxTestContext testContext,
+      Vertx vertx)
+      throws Throwable {
+    // given
+    Action tested = newActionInstance(action, vertx);
+
+    // when
+    tested.apply(new FragmentContext(FRAGMENT, new ClientRequest()),
+        testContext.succeeding(result -> {
+          testContext
+              .verify(() -> {
+                //then
+                ActionLog actionLog = new ActionLog(result.getNodeLog());
+                assertEquals(1, actionLog.getInvocationLogs().size());
+                assertFalse(actionLog.getInvocationLogs().iterator().next().isSuccess());
+              });
+          testContext.completeNow();
+        }));
+
+    assertTrue(testContext.awaitCompletion(5, TimeUnit.SECONDS));
+    if (testContext.failed()) {
+      throw testContext.causeOfFailure();
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideErrorActions")
+  @DisplayName("Expect two invocation logs are added when action and with error error and retry is 1.")
+  void expectTwoInvocationLogsWhenErrorAndRetry(Action action, VertxTestContext testContext,
+      Vertx vertx)
+      throws Throwable {
+    // given
+    Action tested = newInstanceWithRetry(action, vertx);
+
+    // when
+    tested.apply(new FragmentContext(FRAGMENT, new ClientRequest()),
+        testContext.succeeding(result -> {
+          testContext
+              .verify(() -> {
+                //then
+                ActionLog actionLog = new ActionLog(result.getNodeLog());
+                assertEquals("2", actionLog.getLogs().getString(INVOCATION_COUNT_LOG_KEY));
+                assertEquals(2, actionLog.getInvocationLogs().size());
               });
           testContext.completeNow();
         }));
@@ -166,39 +248,55 @@ class CircuitBreakerActionTest {
   }
 
   @Test
-  @DisplayName("Expect fallback transition when action fails.")
-  void expectFallbackWhenFailure(VertxTestContext testContext, Vertx vertx)
+  @DisplayName("Expect DoActionExecuteException in error message when action ends with _error transition.")
+  void expectDoActionExecuteException(VertxTestContext testContext, Vertx vertx)
       throws Throwable {
     // given
-    CircuitBreakerOptions options = new CircuitBreakerOptions()
-        .setFallbackOnFailure(true);
-    CircuitBreaker circuitBreaker = new CircuitBreakerImpl("name", vertx, options);
-
-    CircuitBreakerAction tested = new CircuitBreakerAction(circuitBreaker,
-        CircuitBreakerDoActions::applyFailure, "tested", INFO);
+    Action tested = newActionInstance(CircuitBreakerDoActions::applyErrorTransition, vertx);
 
     // when
     tested.apply(new FragmentContext(FRAGMENT, new ClientRequest()),
-        result -> {
+        testContext.succeeding(result -> {
           testContext
               .verify(() -> {
                 //then
-                assertEquals(FALLBACK_TRANSITION, result.result().getTransition());
-
-                ActionLog actionLog = new ActionLog(result.result().getNodeLog());
-                List<ActionInvocationLog> doActionsLogs = actionLog.getInvocationLogs();
-                assertEquals(1, doActionsLogs.size());
-                ActionInvocationLog invocationLog = doActionsLogs.get(0);
-
-                assertFalse(invocationLog.isSuccess());
-                assertNull(invocationLog.getDoActionLog());
-
+                ActionLog actionLog = new ActionLog(result.getNodeLog());
                 String errorMessage = actionLog.getLogs().getString(ERROR_LOG_KEY);
                 assertNotNull(errorMessage);
-                assertTrue(errorMessage.contains("DoActionExecuteException"));
+                assertTrue(errorMessage.contains(DoActionExecuteException.class.getName()));
               });
           testContext.completeNow();
-        });
+        }));
+
+    assertTrue(testContext.awaitCompletion(5, TimeUnit.SECONDS));
+    if (testContext.failed()) {
+      throw testContext.causeOfFailure();
+    }
+  }
+
+
+  @ParameterizedTest
+  @MethodSource("provideFailureAndExceptionActions")
+  @DisplayName("Expect original exception in error message when action throws an exception or fails.")
+  void expectIllegalStateExceptionWhenThrowsException(Action action, VertxTestContext testContext,
+      Vertx vertx)
+      throws Throwable {
+    // given
+    Action tested = newActionInstance(action, vertx);
+
+    // when
+    tested.apply(new FragmentContext(FRAGMENT, new ClientRequest()),
+        testContext.succeeding(result -> {
+          testContext
+              .verify(() -> {
+                //then
+                ActionLog actionLog = new ActionLog(result.getNodeLog());
+                String errorMessage = actionLog.getLogs().getString(ERROR_LOG_KEY);
+                assertNotNull(errorMessage);
+                assertTrue(errorMessage.contains(IllegalStateException.class.getName()));
+              });
+          testContext.completeNow();
+        }));
 
     assertTrue(testContext.awaitCompletion(5, TimeUnit.SECONDS));
     if (testContext.failed()) {
@@ -207,16 +305,11 @@ class CircuitBreakerActionTest {
   }
 
   @Test
-  @DisplayName("Expect fallback transition when action times out.")
+  @DisplayName("Expect Timeout exception in error message when action times out.")
   void expectFallbackWhenTimout(VertxTestContext testContext, Vertx vertx)
       throws Throwable {
     // given
-    CircuitBreakerOptions options = new CircuitBreakerOptions()
-        .setFallbackOnFailure(true)
-        .setTimeout(TIMEOUT_IN_MS);
-    CircuitBreaker circuitBreaker = new CircuitBreakerImpl("name", vertx, options);
-    CircuitBreakerAction tested = new CircuitBreakerAction(circuitBreaker,
-        CircuitBreakerDoActions.applySuccessDelay(vertx), "tested", INFO);
+    Action tested = newActionInstance(CircuitBreakerDoActions::applySuccessDelay, vertx);
 
     // when
     tested.apply(new FragmentContext(FRAGMENT, new ClientRequest()),
@@ -224,57 +317,14 @@ class CircuitBreakerActionTest {
           testContext
               .verify(() -> {
                 //then
-                assertEquals(FALLBACK_TRANSITION, result.getTransition());
-
                 ActionLog actionLog = new ActionLog(result.getNodeLog());
                 String errorMessage = actionLog.getLogs().getString(ERROR_LOG_KEY);
-                String invocationCount = actionLog.getLogs().getString(INVOCATION_COUNT_LOG_KEY);
-
                 assertNotNull(errorMessage);
-                assertTrue(errorMessage.contains("TimeoutException"));
-                assertEquals("1", invocationCount);
+                assertTrue(errorMessage.contains(TimeoutException.class.getName()));
               });
           testContext.completeNow();
         }));
 
-    assertTrue(testContext.awaitCompletion(5, TimeUnit.SECONDS));
-    if (testContext.failed()) {
-      throw testContext.causeOfFailure();
-    }
-  }
-
-  @Test
-  @DisplayName("Expect fallback transition when action throws exception.")
-  void expectFallbackWhenException(VertxTestContext testContext, Vertx vertx)
-      throws Throwable {
-    // given
-    CircuitBreakerOptions options = new CircuitBreakerOptions()
-        .setFallbackOnFailure(true);
-    CircuitBreaker circuitBreaker = new CircuitBreakerImpl("name", vertx, options);
-
-    CircuitBreakerAction tested = new CircuitBreakerAction(circuitBreaker,
-        CircuitBreakerDoActions::applyException, "tested", INFO);
-
-    // when
-    tested.apply(new FragmentContext(FRAGMENT, new ClientRequest()),
-        testContext.succeeding(result -> {
-          testContext
-              .verify(() -> {
-                assertEquals(FALLBACK_TRANSITION, result.getTransition());
-                ActionLog actionLog = new ActionLog(result.getNodeLog());
-
-                String invocationCount = actionLog.getLogs().getString(INVOCATION_COUNT_LOG_KEY);
-                assertEquals("1", invocationCount);
-
-                String errorMessage = actionLog.getLogs().getString(ERROR_LOG_KEY);
-                assertNotNull(errorMessage);
-                assertTrue(errorMessage.contains("ReplyException"));
-
-              });
-          testContext.completeNow();
-        }));
-
-    //then
     assertTrue(testContext.awaitCompletion(5, TimeUnit.SECONDS));
     if (testContext.failed()) {
       throw testContext.causeOfFailure();
@@ -287,7 +337,7 @@ class CircuitBreakerActionTest {
       throws Throwable {
     validateScenario(
         CircuitBreakerDoActions::applyFailure,
-        CircuitBreakerDoActions::applySuccessWithActionLogs,
+        CircuitBreakerDoActions::applySuccess,
         result -> {
           testContext.verify(() -> {
             //then
@@ -318,7 +368,7 @@ class CircuitBreakerActionTest {
   void expectSuccessWhenErrorThenSuccess(VertxTestContext testContext, Vertx vertx)
       throws Throwable {
     validateScenario(CircuitBreakerDoActions::applyErrorTransition,
-        CircuitBreakerDoActions::applySuccessWithActionLogs, result -> {
+        CircuitBreakerDoActions::applySuccess, result -> {
           //then
           testContext.verify(() -> {
             FragmentResult fragmentResult = result.result();
@@ -382,7 +432,7 @@ class CircuitBreakerActionTest {
       throws Throwable {
     validateScenario(
         CircuitBreakerDoActions::applyFailure,
-        CircuitBreakerDoActions.applySuccessDelay(vertx),
+        CircuitBreakerDoActions::applySuccessDelay,
         result -> {
           //then
           testContext.verify(() -> {
@@ -407,7 +457,7 @@ class CircuitBreakerActionTest {
   void expectFallbackWhenTimeoutThenFailure(VertxTestContext testContext, Vertx vertx)
       throws Throwable {
     validateScenario(
-        CircuitBreakerDoActions.applySuccessDelay(vertx),
+        CircuitBreakerDoActions::applySuccessDelay,
         CircuitBreakerDoActions::applyFailure,
         result -> {
           testContext.verify(() -> {
@@ -436,8 +486,8 @@ class CircuitBreakerActionTest {
   void expectFallbackWhenTimeouts(VertxTestContext testContext, Vertx vertx)
       throws Throwable {
     validateScenario(
-        CircuitBreakerDoActions.applySuccessDelay(vertx),
-        CircuitBreakerDoActions.applySuccessDelay(vertx),
+        CircuitBreakerDoActions::applySuccessDelay,
+        CircuitBreakerDoActions::applySuccessDelay,
         result -> {
           testContext.verify(() -> {
             //then
@@ -464,8 +514,8 @@ class CircuitBreakerActionTest {
   void expectSuccessWhenTimeoutThenSuccess(VertxTestContext testContext, Vertx vertx)
       throws Throwable {
     validateScenario(
-        CircuitBreakerDoActions.applySuccessDelay(vertx, 800),
-        CircuitBreakerDoActions::applySuccessWithActionLogs,
+        CircuitBreakerDoActions::applySuccessDelay,
+        CircuitBreakerDoActions::applySuccess,
         result -> {
           testContext.verify(() -> {
             //then
@@ -498,11 +548,36 @@ class CircuitBreakerActionTest {
             ActionLog actionLog = new ActionLog(fragmentResult.getNodeLog());
             List<ActionInvocationLog> doActionsLogs = actionLog.getInvocationLogs();
             String invocationCount = actionLog.getLogs().getString(INVOCATION_COUNT_LOG_KEY);
-            assertEquals(0, doActionsLogs.size());
+            assertEquals(2, doActionsLogs.size());
             assertEquals("2", invocationCount);
           });
           testContext.completeNow();
         }, testContext, vertx);
+  }
+
+  private Action newActionInstance(Action action, Vertx vertx) {
+    return new CircuitBreakerActionFactory().create("alias",
+        new CircuitBreakerActionFactoryOptions()
+            .setCircuitBreakerOptions(new CircuitBreakerOptions().setTimeout(TIMEOUT_IN_MS))
+            .toJson(), vertx, action);
+  }
+
+  private Action newInstanceWithRetry(Action action, Vertx vertx) {
+    return new CircuitBreakerActionFactory().create("alias",
+        new CircuitBreakerActionFactoryOptions()
+            .setCircuitBreakerOptions(
+                new CircuitBreakerOptions().setTimeout(TIMEOUT_IN_MS).setMaxRetries(1)).toJson(),
+        vertx,
+        action);
+  }
+
+  private Action newInstanceWithInfo(Action action, Vertx vertx) {
+    return new CircuitBreakerActionFactory().create("alias",
+        new CircuitBreakerActionFactoryOptions()
+            .setCircuitBreakerOptions(new CircuitBreakerOptions().setTimeout(TIMEOUT_IN_MS))
+            .setLogLevel(INFO.getLevel()).toJson(),
+        vertx,
+        action);
   }
 
   private void validateScenario(Action firstInvocationBehaviour, Action secondInvocationBehaviour,
@@ -528,5 +603,37 @@ class CircuitBreakerActionTest {
     if (testContext.failed()) {
       throw testContext.causeOfFailure();
     }
+  }
+
+  private static Stream<Action> provideAllActions() {
+    return Stream.concat(provideSuccessActions(), provideErrorActionsAndTimeout());
+  }
+
+  private static Stream<Action> provideSuccessActions() {
+    return Stream.of(
+        CircuitBreakerDoActions::applySuccess
+    );
+  }
+
+  private static Stream<Action> provideErrorActionsAndTimeout() {
+    return Stream.concat(
+        provideErrorActions(),
+        Stream.of(CircuitBreakerDoActions::applySuccessDelay)
+    );
+  }
+
+  private static Stream<Action> provideErrorActions() {
+    return Stream.concat(
+        provideFailureAndExceptionActions(),
+        Stream
+            .of(CircuitBreakerDoActions::applyException)
+    );
+  }
+
+  private static Stream<Action> provideFailureAndExceptionActions() {
+    return Stream.of(
+        CircuitBreakerDoActions::applyFailure,
+        CircuitBreakerDoActions::applyException
+    );
   }
 }

--- a/handler/core/src/test/java/io/knotx/fragments/task/factory/DefaultTaskFactoryConfigTest.java
+++ b/handler/core/src/test/java/io/knotx/fragments/task/factory/DefaultTaskFactoryConfigTest.java
@@ -30,31 +30,21 @@ import org.junit.jupiter.api.extension.ExtendWith;
 class DefaultTaskFactoryConfigTest {
 
   @Test
-  @DisplayName("Expect all node factories do not contain log level when global is not configured")
+  @DisplayName("Expect all node factories contain log level ERROR when global is not configured")
   void expectNoLogLevel(Vertx vertx) throws Throwable {
-    verify("task/factory/taskFactoryWithNoGlobalLogLevel.conf", validateNoGlobalNodeLog(), vertx);
+    verify("task/factory/taskFactoryWithNoGlobalLogLevel.conf", validateNodeLog("error"), vertx);
   }
 
   @Test
   @DisplayName("Expect all node factories contain log level when global is configured")
   void expectLogLevel(Vertx vertx) throws Throwable {
-    verify("task/factory/taskFactoryWithGlobalLogLevel.conf", validateNodeLog("INFO"), vertx);
+    verify("task/factory/taskFactoryWithGlobalLogLevel.conf", validateNodeLog("info"), vertx);
   }
 
   @Test
   @DisplayName("Expect local node log level is not overridden by global one")
   void expectLocalLogLevel(Vertx vertx) throws Throwable {
-    verify("task/factory/taskFactoryWithLocalLogLevel.conf", validateNodeLog("ERROR"), vertx);
-  }
-
-  private Consumer<JsonObject> validateNoGlobalNodeLog() {
-    return config -> {
-      DefaultTaskFactoryConfig factoryConfig = new DefaultTaskFactoryConfig(config);
-      factoryConfig.getNodeFactories().forEach(
-          nodeFactoryOptions -> Assertions
-              .assertNull(new LogLevelConfig(nodeFactoryOptions.getConfig()).getLogLevel())
-      );
-    };
+    verify("task/factory/taskFactoryWithLocalLogLevel.conf", validateNodeLog("error"), vertx);
   }
 
   private Consumer<JsonObject> validateNodeLog(String logLevel) {

--- a/handler/core/src/test/resources/task/factory/taskFactoryWithGlobalLogLevel.conf
+++ b/handler/core/src/test/resources/task/factory/taskFactoryWithGlobalLogLevel.conf
@@ -1,4 +1,4 @@
-logLevel = INFO
+logLevel = info
 
 nodeFactories = [
   {

--- a/handler/core/src/test/resources/task/factory/taskFactoryWithLocalLogLevel.conf
+++ b/handler/core/src/test/resources/task/factory/taskFactoryWithLocalLogLevel.conf
@@ -1,10 +1,10 @@
-logLevel = INFO
+logLevel = info
 
 nodeFactories = [
   {
     factory = action
     config {
-      logLevel = ERROR
+      logLevel = error
     }
   }
 ]


### PR DESCRIPTION
Adds a node logs mechanism to the circuit breaker action && forces fallback on failure strategy. 

## Description
Adds support for node's logs in circuit breaker action. It affects the action log syntax allowing to specify more `doAction` invocations. You can enable those logs with the `logLevel=info` option.

Moreover, the circuit breaker action forces now the fallback on failure strategy. It means that setting `fallbackOnFailure=true` is not required. So every time a surrounded action responds with `_error` transition, throws an exception or simply times out, then `_fallback` transition is returned.

It also replaces the `fallback` transition with `_fallback` when circuit breaker action used. 

## Upgrade notes (if appropriate)

### Replace the `fallback` transition with `_fallback`
#### Before
```
books-listing {
  action = book-with-circuit-breaker
  onTransitions._fallback {
    action = book-inline-body-fallback
  }
}
```
#### After
```
books-listing {
  action = book-with-circuit-breaker
  onTransitions.fallback {
    action = book-inline-body-fallback
  }
}
```

### Circuit breaker action forces fallback strategy
Circuit breaker action forces fallback strategy. Setting:
 ```
circuitBreakerOptions.fallbackOnFailure=false
``` 
does not affect circuit breaker behaviour.

So every time a surrounded action responds with _error, throws an exception or simply times out, then `_fallback` transition is returned.

#### Before
```
circuitBreakerOptions {
  fallbackOnFailure=false
  timeout = 1000
  ...
}
```
#### After
```
circuitBreakerOptions {
  # fallbackOnFailure=true
  timeout = 1000
  ...
}
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [code style](/CONTRIBUTING.md#coding-conventions) of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

---
I hereby agree to the terms of the Knot.x Contributor License Agreement.
