### PR TITLE
Feature/#69 cb retries when custom error transition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to `knotx-fragments` will be documented in this file.
 
 ## Unreleased
 List of changes that are finished but not yet released in any final version.
+- [PR-80](https://github.com/Knotx/knotx-fragments/pull/80) - Circuit breaker understands which custom transition mean error.
 - [PR-84](https://github.com/Knotx/knotx-fragments/pull/84) - Adding node log to inline payload action.
 - [PR-83](https://github.com/Knotx/knotx-fragments/pull/83) - Adding node log to inline body action.
 - [PR-82](https://github.com/Knotx/knotx-fragments/pull/82) - Adding logging to in-memory cache action.

--- a/handler/README.md
+++ b/handler/README.md
@@ -517,6 +517,9 @@ config {
     # time spent in open state before attempting to re-try
     resetTimeout = 10000
   }
+  # transitions from doAction that mean error
+  errorTransitions = [ _error, custom ]
+  logLevel = INFO
 }
 doAction = product
 ```
@@ -532,6 +535,8 @@ error or times out then the custom `_fallback` transition is returned.
 | Failure               | TIMEOUT                |  `_fallback`, [e,t]      |
 | TIMEOUT               | Failure                |  `_fallback`, [t,e]      |
 | TIMEOUT               | TIMEOUT                | `_fallback`, [t,t]       |
+| custom transition     | -                      |  `_success`, [s]         |
+| custom transition that means error  | custom transition that means error | `_error`, [e,e]        |
 
 Labels:
 - TIMEOUT - `doAction` does not end withing the required time (`circuitBreakerOptions.timeout`), 

--- a/handler/core/docs/asciidoc/dataobjects.adoc
+++ b/handler/core/docs/asciidoc/dataobjects.adoc
@@ -78,6 +78,9 @@ Sets the circuit breaker name.
 Sets the circuit breaker configuration options. Note that Knot.x enforce the fallback on error
  strategy.
 +++
+|[[errorTransitions]]`@errorTransitions`|`Array of String`|+++
+Sets error transitions.
++++
 |[[logLevel]]`@logLevel`|`String`|+++
 Sets the action node log level.
 +++

--- a/handler/core/src/main/java/io/knotx/fragments/handler/action/cb/CircuitBreakerActionFactory.java
+++ b/handler/core/src/main/java/io/knotx/fragments/handler/action/cb/CircuitBreakerActionFactory.java
@@ -52,6 +52,6 @@ public class CircuitBreakerActionFactory implements ActionFactory {
         options.getCircuitBreakerOptions());
 
     return new CircuitBreakerAction(circuitBreaker, doAction, alias,
-        fromConfig(options.getLogLevel()));
+        fromConfig(options.getLogLevel()), options.getErrorTransitions());
   }
 }

--- a/handler/core/src/main/java/io/knotx/fragments/handler/action/cb/CircuitBreakerActionFactoryOptions.java
+++ b/handler/core/src/main/java/io/knotx/fragments/handler/action/cb/CircuitBreakerActionFactoryOptions.java
@@ -16,10 +16,13 @@
 package io.knotx.fragments.handler.action.cb;
 
 import static io.knotx.fragments.handler.api.actionlog.ActionLogLevel.ERROR;
+import static io.knotx.fragments.handler.api.domain.FragmentResult.ERROR_TRANSITION;
 
 import io.vertx.circuitbreaker.CircuitBreakerOptions;
 import io.vertx.codegen.annotations.DataObject;
 import io.vertx.core.json.JsonObject;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.UUID;
 import org.apache.commons.lang3.StringUtils;
 
@@ -31,12 +34,11 @@ public class CircuitBreakerActionFactoryOptions {
    */
   private static final boolean DEFAULT_FALLBACK_ON_FAILURE = true;
 
-  private static final CircuitBreakerOptions DEFAULT_CIRCUIT_BREAKER_OPTIONS = initCircuitBreakerOptions(
-      new CircuitBreakerOptions());
-
   private String circuitBreakerName;
 
-  private CircuitBreakerOptions circuitBreakerOptions = DEFAULT_CIRCUIT_BREAKER_OPTIONS;
+  private CircuitBreakerOptions circuitBreakerOptions = new CircuitBreakerOptions();
+
+  private Set<String> errorTransitions = new HashSet<>();
 
   private String logLevel = ERROR.getLevel();
 
@@ -55,13 +57,6 @@ public class CircuitBreakerActionFactoryOptions {
    */
   public CircuitBreakerActionFactoryOptions(JsonObject json) {
     CircuitBreakerActionFactoryOptionsConverter.fromJson(json, this);
-    this.circuitBreakerOptions = initCircuitBreakerOptions(circuitBreakerOptions);
-  }
-
-  private static CircuitBreakerOptions initCircuitBreakerOptions(CircuitBreakerOptions options) {
-    CircuitBreakerOptions newOptions = new CircuitBreakerOptions(options);
-    newOptions.setFallbackOnFailure(DEFAULT_FALLBACK_ON_FAILURE);
-    return newOptions;
   }
 
   /**
@@ -96,7 +91,9 @@ public class CircuitBreakerActionFactoryOptions {
    * @return the circuit breaker configuration options
    */
   public CircuitBreakerOptions getCircuitBreakerOptions() {
-    return circuitBreakerOptions;
+    CircuitBreakerOptions result = new CircuitBreakerOptions(circuitBreakerOptions);
+    result.setFallbackOnFailure(DEFAULT_FALLBACK_ON_FAILURE);
+    return result;
   }
 
   /**
@@ -109,6 +106,26 @@ public class CircuitBreakerActionFactoryOptions {
   public CircuitBreakerActionFactoryOptions setCircuitBreakerOptions(
       CircuitBreakerOptions circuitBreakerOptions) {
     this.circuitBreakerOptions = circuitBreakerOptions;
+    return this;
+  }
+
+  /**
+   * @return transitions that mean error
+   */
+  public Set<String> getErrorTransitions() {
+    Set<String> result = new HashSet<>(errorTransitions);
+    result.add(ERROR_TRANSITION);
+    return result;
+  }
+
+  /**
+   * Sets error transitions.
+   *
+   * @param errorTransitions transitions that mean error
+   * @return the current {@link CircuitBreakerActionFactoryOptions} instance
+   */
+  public CircuitBreakerActionFactoryOptions setErrorTransitions(Set<String> errorTransitions) {
+    this.errorTransitions = errorTransitions;
     return this;
   }
 
@@ -128,5 +145,15 @@ public class CircuitBreakerActionFactoryOptions {
   public CircuitBreakerActionFactoryOptions setLogLevel(String logLevel) {
     this.logLevel = logLevel;
     return this;
+  }
+
+  @Override
+  public String toString() {
+    return "CircuitBreakerActionFactoryOptions{" +
+        "circuitBreakerName='" + circuitBreakerName + '\'' +
+        ", circuitBreakerOptions=" + circuitBreakerOptions +
+        ", errorTransitions=" + errorTransitions +
+        ", logLevel='" + logLevel + '\'' +
+        '}';
   }
 }

--- a/handler/core/src/test/java/io/knotx/fragments/handler/action/cb/CircuitBreakerActionFactoryOptionsTest.java
+++ b/handler/core/src/test/java/io/knotx/fragments/handler/action/cb/CircuitBreakerActionFactoryOptionsTest.java
@@ -20,6 +20,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.vertx.circuitbreaker.CircuitBreakerOptions;
 import io.vertx.core.json.JsonObject;
+import java.util.HashSet;
+import java.util.Set;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.platform.commons.util.StringUtils;
@@ -54,5 +56,20 @@ class CircuitBreakerActionFactoryOptionsTest {
     // then
     assertNotNull(tested.getCircuitBreakerName());
     assertTrue(StringUtils.isNotBlank(tested.getCircuitBreakerName()));
+  }
+
+  @DisplayName("Expect _error transition is added to error transition set.")
+  @Test
+  void expectErrorTransitionConfigured() {
+    //given
+    Set<String> errorTransitions = new HashSet<>();
+    JsonObject json = new CircuitBreakerActionFactoryOptions()
+        .setErrorTransitions(errorTransitions).toJson();
+
+    // when
+    CircuitBreakerActionFactoryOptions tested = new CircuitBreakerActionFactoryOptions(json);
+
+    // then
+    assertTrue(tested.getErrorTransitions().contains("_error"));
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Ability to add custom `errorTransitions` to Circuit Breaker Action config. This pull request is related to https://github.com/Knotx/knotx-fragments/issues/69

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](/CONTRIBUTING.md#coding-conventions) of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

---
I hereby agree to the terms of the Knot.x Contributor License Agreement.
