### PR TITLE
#68 Fixes failing concurrent test by relaxing ordering requirements

### DIFF
--- a/handler/engine/src/test/java/io/knotx/fragments/engine/FragmentEventLogVerifier.java
+++ b/handler/engine/src/test/java/io/knotx/fragments/engine/FragmentEventLogVerifier.java
@@ -95,6 +95,12 @@ class FragmentEventLogVerifier {
           null);
     }
 
+    static Operation range(String task, String node, String status, int minPosition,
+        int maxPosition, JsonObject nodeLog) {
+      return new Operation(task, node, status, new RangePosition(minPosition, maxPosition),
+          nodeLog);
+    }
+
     public Position getPosition() {
       return position;
     }

--- a/handler/engine/src/test/java/io/knotx/fragments/engine/TaskEngineCompositeNodeTest.java
+++ b/handler/engine/src/test/java/io/knotx/fragments/engine/TaskEngineCompositeNodeTest.java
@@ -127,9 +127,9 @@ class TaskEngineCompositeNodeTest {
     // then
     verifyExecution(result, testContext,
         event -> verifyAllLogEntries(event.getLogAsJson(),
-            Operation.exact("task", "action", "SUCCESS", 0, successNodeLog),
-            Operation.exact("task", "action1", "SUCCESS", 1),
-            Operation.exact("task", "action2", "SUCCESS", 2, successNode2Log),
+            Operation.range("task", "action", "SUCCESS", 0, 2, successNodeLog),
+            Operation.range("task", "action1", "SUCCESS", 0, 2),
+            Operation.range("task", "action2", "SUCCESS", 0, 2, successNode2Log),
             Operation.exact("task", COMPOSITE_NODE_ID, "SUCCESS", 3)
         ));
   }


### PR DESCRIPTION
The ordering requirement is relaxed for order of log events produced by SingleNodes under tested CompositeNode.

## Description
Created a new range Position constructor allowing specifying ranges and provide nodeLog.
Then applied for the test to allow any ordering of inner log entries.

## Motivation and Context
Fixes #68 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the [code style](/CONTRIBUTING.md#coding-conventions) of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---
I hereby agree to the terms of the Knot.x Contributor License Agreement.
