### PR TITLE
Feature/#93 nodes with metadata

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/handler/core/build.gradle.kts
+++ b/handler/core/build.gradle.kts
@@ -47,6 +47,7 @@ dependencies {
     testImplementation(group = "io.vertx", name = "vertx-config-hocon")
     testImplementation("org.junit.jupiter:junit-jupiter-params")
     testImplementation(group = "com.github.tomakehurst", name = "wiremock")
+    testImplementation(group = "commons-io", name = "commons-io", version = "2.4")
 }
 
 tasks {

--- a/handler/core/src/main/java/io/knotx/fragments/handler/FragmentsHandler.java
+++ b/handler/core/src/main/java/io/knotx/fragments/handler/FragmentsHandler.java
@@ -25,7 +25,7 @@ import io.knotx.fragments.engine.FragmentEventContextTaskAware;
 import io.knotx.fragments.engine.FragmentsEngine;
 import io.knotx.fragments.engine.Task;
 import io.knotx.fragments.handler.consumer.FragmentEventsConsumerProvider;
-import io.knotx.fragments.task.TasksEventsWrapper;
+import io.knotx.fragments.task.TasksWithFragmentEvents;
 import io.knotx.fragments.task.factory.node.NodeWithMetadata;
 import io.knotx.server.api.context.ClientRequest;
 import io.knotx.server.api.context.RequestContext;
@@ -82,20 +82,20 @@ public class FragmentsHandler implements Handler<RoutingContext> {
         );
   }
 
-  protected Single<TasksEventsWrapper> doHandle(List<Fragment> fragments,
+  protected Single<TasksWithFragmentEvents> doHandle(List<Fragment> fragments,
       ClientRequest clientRequest) {
     return Single.just(fragments)
         .map(f -> toEvents(f, clientRequest))
         .flatMap(events -> engine.execute(events)
-            .map(fragmentEvents -> new TasksEventsWrapper(events.stream()
+            .map(fragmentEvents -> new TasksWithFragmentEvents(events.stream()
                 .map(FragmentEventContextTaskAware::getTask)
                 .collect(Collectors.toList()), fragmentEvents)));
   }
 
   private void enrichWithEventConsumers(ClientRequest clientRequest,
-      TasksEventsWrapper tasksEventsWrapper) {
+      TasksWithFragmentEvents tasksWithFragmentEvents) {
     fragmentEventsConsumerProvider.provide()
-        .forEach(consumer -> consumer.accept(clientRequest, tasksEventsWrapper));
+        .forEach(consumer -> consumer.accept(clientRequest, tasksWithFragmentEvents));
   }
 
   private void putFragments(RoutingContext routingContext, List<FragmentEvent> events) {

--- a/handler/core/src/main/java/io/knotx/fragments/handler/consumer/FragmentEventsConsumer.java
+++ b/handler/core/src/main/java/io/knotx/fragments/handler/consumer/FragmentEventsConsumer.java
@@ -15,7 +15,7 @@
  */
 package io.knotx.fragments.handler.consumer;
 
-import io.knotx.fragments.task.TasksEventsWrapper;
+import io.knotx.fragments.task.TasksWithFragmentEvents;
 import io.knotx.server.api.context.ClientRequest;
 
 import io.knotx.fragments.engine.FragmentEvent;
@@ -31,6 +31,6 @@ public interface FragmentEventsConsumer {
    *  @param clientRequest - client request
    * @param tasksEvents - all fragment events
    */
-  void accept(ClientRequest clientRequest, TasksEventsWrapper tasksEvents);
+  void accept(ClientRequest clientRequest, TasksWithFragmentEvents tasksEvents);
 
 }

--- a/handler/core/src/main/java/io/knotx/fragments/handler/consumer/FragmentEventsConsumer.java
+++ b/handler/core/src/main/java/io/knotx/fragments/handler/consumer/FragmentEventsConsumer.java
@@ -15,8 +15,8 @@
  */
 package io.knotx.fragments.handler.consumer;
 
+import io.knotx.fragments.task.TasksEventsWrapper;
 import io.knotx.server.api.context.ClientRequest;
-import java.util.List;
 
 import io.knotx.fragments.engine.FragmentEvent;
 
@@ -28,10 +28,9 @@ public interface FragmentEventsConsumer {
 
   /**
    * Gets a list of processed and unprocessed fragments.
-   *
-   * @param clientRequest - client request
-   * @param fragmentEvents - all fragment events
+   *  @param clientRequest - client request
+   * @param tasksEvents - all fragment events
    */
-  void accept(ClientRequest clientRequest, List<FragmentEvent> fragmentEvents);
+  void accept(ClientRequest clientRequest, TasksEventsWrapper tasksEvents);
 
 }

--- a/handler/core/src/main/java/io/knotx/fragments/handler/consumer/FragmentHtmlBodyWriterFactory.java
+++ b/handler/core/src/main/java/io/knotx/fragments/handler/consumer/FragmentHtmlBodyWriterFactory.java
@@ -17,8 +17,8 @@ package io.knotx.fragments.handler.consumer;
 
 import io.knotx.fragments.api.Fragment;
 import io.knotx.fragments.engine.FragmentEvent;
-import io.knotx.fragments.task.TaskEventWrapper;
-import io.knotx.fragments.task.TasksEventsWrapper;
+import io.knotx.fragments.task.TaskWithFragmentEvent;
+import io.knotx.fragments.task.TasksWithFragmentEvents;
 import io.knotx.fragments.task.factory.node.NodeWithMetadata;
 import io.knotx.server.api.context.ClientRequest;
 import io.vertx.core.json.JsonArray;
@@ -55,32 +55,32 @@ public class FragmentHtmlBodyWriterFactory implements FragmentEventsConsumerFact
       private String requestParam = getConditionParam(config);
 
       @Override
-      public void accept(ClientRequest request, TasksEventsWrapper tasksEvents) {
+      public void accept(ClientRequest request, TasksWithFragmentEvents tasksEvents) {
         if (containsHeader(request) || containsParam(request)) {
           tasksEvents.stream()
-              .filter(taskEventWrapper -> isSupported(taskEventWrapper.getFragmentEvent()))
+              .filter(taskWithFragmentEvent -> isSupported(taskWithFragmentEvent.getFragmentEvent()))
               .forEach(this::wrapFragmentBody);
         }
       }
 
-      private void wrapFragmentBody(TaskEventWrapper taskEventWrapper) {
-        Fragment fragment = taskEventWrapper.getFragmentEvent().getFragment();
+      private void wrapFragmentBody(TaskWithFragmentEvent taskWithFragmentEvent) {
+        Fragment fragment = taskWithFragmentEvent.getFragmentEvent().getFragment();
         fragment.setBody("<!-- data-knotx-id=\"" + fragment.getId() + "\" -->"
-            + addAsScript(taskEventWrapper)
+            + addAsScript(taskWithFragmentEvent)
             + fragment.getBody()
             + "<!-- data-knotx-id=\"" + fragment.getId() + "\" -->");
       }
 
-      private String addAsScript(TaskEventWrapper taskEventWrapper) {
-        return "<script data-knotx-debug=\"log\" data-knotx-id=\"" + taskEventWrapper.getFragmentEvent().getFragment().getId()
+      private String addAsScript(TaskWithFragmentEvent taskWithFragmentEvent) {
+        return "<script data-knotx-debug=\"log\" data-knotx-id=\"" + taskWithFragmentEvent.getFragmentEvent().getFragment().getId()
             + "\" type=\"application/json\">"
-            + taskEventWrapper.getFragmentEvent().toJson()
+            + taskWithFragmentEvent.getFragmentEvent().toJson()
             + "</script>"
-            + taskEventWrapper.getTask().getRootNode()
-            .map(NodeWithMetadata::getData)
+            + taskWithFragmentEvent.getTask().getRootNode()
+            .map(NodeWithMetadata::generateMetadata)
             .map(JsonObject::toString)
             .map(graphData ->
-                "<script data-knotx-debug=\"graph\" data-knotx-id=\"" + taskEventWrapper.getFragmentEvent().getFragment().getId()
+                "<script data-knotx-debug=\"graph\" data-knotx-id=\"" + taskWithFragmentEvent.getFragmentEvent().getFragment().getId()
                     + "\" type=\"application/json\">"
                     + graphData
                     + "</script>")

--- a/handler/core/src/main/java/io/knotx/fragments/task/TaskEventWrapper.java
+++ b/handler/core/src/main/java/io/knotx/fragments/task/TaskEventWrapper.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2019 Knot.x Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.knotx.fragments.task;
+
+import io.knotx.fragments.engine.FragmentEvent;
+import io.knotx.fragments.engine.Task;
+import io.knotx.fragments.task.factory.node.NodeWithMetadata;
+import java.util.Objects;
+
+public class TaskEventWrapper {
+
+  private Task<NodeWithMetadata> task;
+
+  private FragmentEvent fragmentEvent;
+
+  public TaskEventWrapper(Task<NodeWithMetadata> task, FragmentEvent fragmentEvent) {
+    this.task = task;
+    this.fragmentEvent = fragmentEvent;
+  }
+
+  public Task<NodeWithMetadata> getTask() {
+    return task;
+  }
+
+  public FragmentEvent getFragmentEvent() {
+    return fragmentEvent;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    TaskEventWrapper that = (TaskEventWrapper) o;
+    return Objects.equals(task, that.task) &&
+        Objects.equals(fragmentEvent, that.fragmentEvent);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(task, fragmentEvent);
+  }
+}

--- a/handler/core/src/main/java/io/knotx/fragments/task/TaskFactory.java
+++ b/handler/core/src/main/java/io/knotx/fragments/task/TaskFactory.java
@@ -17,6 +17,7 @@ package io.knotx.fragments.task;
 
 import io.knotx.fragments.engine.FragmentEventContext;
 import io.knotx.fragments.engine.Task;
+import io.knotx.fragments.engine.graph.Node;
 import io.knotx.fragments.handler.FragmentsHandlerOptions;
 import io.knotx.fragments.handler.api.exception.ConfigurationException;
 import io.vertx.core.json.JsonObject;
@@ -28,7 +29,7 @@ import io.vertx.reactivex.core.Vertx;
  *
  * Task factories are configured in {@link FragmentsHandlerOptions#getTaskFactories()}.
  */
-public interface TaskFactory {
+public interface TaskFactory <T extends Node> {
 
   /**
    * @return task factory name
@@ -43,7 +44,7 @@ public interface TaskFactory {
    * @param vertx vertx instance
    * @return a reference to this, so the API can be used fluently
    */
-  TaskFactory configure(JsonObject config, Vertx vertx);
+  TaskFactory<T> configure(JsonObject config, Vertx vertx);
 
   /**
    * Determines if a fragment event context can be processed by the factory.
@@ -61,5 +62,5 @@ public interface TaskFactory {
    * @param context fragment event context
    * @return new task instance
    */
-  Task newInstance(FragmentEventContext context);
+  Task<T> newInstance(FragmentEventContext context);
 }

--- a/handler/core/src/main/java/io/knotx/fragments/task/TaskWithFragmentEvent.java
+++ b/handler/core/src/main/java/io/knotx/fragments/task/TaskWithFragmentEvent.java
@@ -20,13 +20,13 @@ import io.knotx.fragments.engine.Task;
 import io.knotx.fragments.task.factory.node.NodeWithMetadata;
 import java.util.Objects;
 
-public class TaskEventWrapper {
+public class TaskWithFragmentEvent {
 
   private Task<NodeWithMetadata> task;
 
   private FragmentEvent fragmentEvent;
 
-  public TaskEventWrapper(Task<NodeWithMetadata> task, FragmentEvent fragmentEvent) {
+  public TaskWithFragmentEvent(Task<NodeWithMetadata> task, FragmentEvent fragmentEvent) {
     this.task = task;
     this.fragmentEvent = fragmentEvent;
   }
@@ -47,7 +47,7 @@ public class TaskEventWrapper {
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    TaskEventWrapper that = (TaskEventWrapper) o;
+    TaskWithFragmentEvent that = (TaskWithFragmentEvent) o;
     return Objects.equals(task, that.task) &&
         Objects.equals(fragmentEvent, that.fragmentEvent);
   }

--- a/handler/core/src/main/java/io/knotx/fragments/task/TasksEventsWrapper.java
+++ b/handler/core/src/main/java/io/knotx/fragments/task/TasksEventsWrapper.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2019 Knot.x Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.knotx.fragments.task;
+
+import com.google.common.collect.Streams;
+import io.knotx.fragments.engine.FragmentEvent;
+import io.knotx.fragments.engine.Task;
+import io.knotx.fragments.task.factory.node.NodeWithMetadata;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Stream;
+
+public class TasksEventsWrapper {
+
+  private List<Task<NodeWithMetadata>> tasks;
+
+  private List<FragmentEvent> fragmentEvents;
+
+  public TasksEventsWrapper(List<Task<NodeWithMetadata>> tasks, List<FragmentEvent> fragmentEvents) {
+    this.tasks = tasks;
+    this.fragmentEvents = fragmentEvents;
+  }
+
+  public Stream<TaskEventWrapper> stream() {
+    return Streams.zip(tasks.stream(), fragmentEvents.stream(), TaskEventWrapper::new);
+  }
+
+  public List<Task<NodeWithMetadata>> getTasks() {
+    return tasks;
+  }
+
+  public List<FragmentEvent> getFragmentEvents() {
+    return fragmentEvents;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    TasksEventsWrapper tasksEventsWrapper = (TasksEventsWrapper) o;
+    return Objects.equals(tasks, tasksEventsWrapper.tasks) &&
+        Objects.equals(fragmentEvents, tasksEventsWrapper.fragmentEvents);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(tasks, fragmentEvents);
+  }
+}

--- a/handler/core/src/main/java/io/knotx/fragments/task/TasksWithFragmentEvents.java
+++ b/handler/core/src/main/java/io/knotx/fragments/task/TasksWithFragmentEvents.java
@@ -23,19 +23,19 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Stream;
 
-public class TasksEventsWrapper {
+public class TasksWithFragmentEvents {
 
   private List<Task<NodeWithMetadata>> tasks;
 
   private List<FragmentEvent> fragmentEvents;
 
-  public TasksEventsWrapper(List<Task<NodeWithMetadata>> tasks, List<FragmentEvent> fragmentEvents) {
+  public TasksWithFragmentEvents(List<Task<NodeWithMetadata>> tasks, List<FragmentEvent> fragmentEvents) {
     this.tasks = tasks;
     this.fragmentEvents = fragmentEvents;
   }
 
-  public Stream<TaskEventWrapper> stream() {
-    return Streams.zip(tasks.stream(), fragmentEvents.stream(), TaskEventWrapper::new);
+  public Stream<TaskWithFragmentEvent> stream() {
+    return Streams.zip(tasks.stream(), fragmentEvents.stream(), TaskWithFragmentEvent::new);
   }
 
   public List<Task<NodeWithMetadata>> getTasks() {
@@ -54,9 +54,9 @@ public class TasksEventsWrapper {
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    TasksEventsWrapper tasksEventsWrapper = (TasksEventsWrapper) o;
-    return Objects.equals(tasks, tasksEventsWrapper.tasks) &&
-        Objects.equals(fragmentEvents, tasksEventsWrapper.fragmentEvents);
+    TasksWithFragmentEvents tasksWithFragmentEvents = (TasksWithFragmentEvents) o;
+    return Objects.equals(tasks, tasksWithFragmentEvents.tasks) &&
+        Objects.equals(fragmentEvents, tasksWithFragmentEvents.fragmentEvents);
   }
 
   @Override

--- a/handler/core/src/main/java/io/knotx/fragments/task/factory/DefaultTaskFactory.java
+++ b/handler/core/src/main/java/io/knotx/fragments/task/factory/DefaultTaskFactory.java
@@ -23,6 +23,7 @@ import io.knotx.fragments.engine.graph.Node;
 import io.knotx.fragments.task.TaskFactory;
 import io.knotx.fragments.task.exception.NodeFactoryNotFoundException;
 import io.knotx.fragments.task.factory.node.NodeFactory;
+import io.knotx.fragments.task.factory.node.NodeWithMetadata;
 import io.vertx.core.json.JsonObject;
 import io.vertx.reactivex.core.Vertx;
 import java.util.HashMap;
@@ -83,7 +84,7 @@ public class DefaultTaskFactory implements TaskFactory, NodeProvider {
   }
 
   @Override
-  public Node initNode(GraphNodeOptions nodeOptions) {
+  public NodeWithMetadata initNode(GraphNodeOptions nodeOptions) {
     return findNodeFactory(nodeOptions)
         .map(f -> f.initNode(nodeOptions, initTransitions(nodeOptions), this))
         .orElseThrow(() -> new NodeFactoryNotFoundException(nodeOptions.getNode().getFactory()));
@@ -93,9 +94,9 @@ public class DefaultTaskFactory implements TaskFactory, NodeProvider {
     return Optional.ofNullable(nodeFactories.get(nodeOptions.getNode().getFactory()));
   }
 
-  private Map<String, Node> initTransitions(GraphNodeOptions nodeOptions) {
+  private Map<String, NodeWithMetadata> initTransitions(GraphNodeOptions nodeOptions) {
     Map<String, GraphNodeOptions> transitions = nodeOptions.getOnTransitions();
-    Map<String, Node> edges = new HashMap<>();
+    Map<String, NodeWithMetadata> edges = new HashMap<>();
     transitions.forEach((transition, childGraphOptions) -> edges
         .put(transition, initNode(childGraphOptions)));
     return edges;

--- a/handler/core/src/main/java/io/knotx/fragments/task/factory/DefaultTaskFactory.java
+++ b/handler/core/src/main/java/io/knotx/fragments/task/factory/DefaultTaskFactory.java
@@ -19,7 +19,6 @@ import io.knotx.fragments.handler.api.exception.ConfigurationException;
 import io.knotx.fragments.api.Fragment;
 import io.knotx.fragments.engine.FragmentEventContext;
 import io.knotx.fragments.engine.Task;
-import io.knotx.fragments.engine.graph.Node;
 import io.knotx.fragments.task.TaskFactory;
 import io.knotx.fragments.task.exception.NodeFactoryNotFoundException;
 import io.knotx.fragments.task.factory.node.NodeFactory;
@@ -36,7 +35,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
-public class DefaultTaskFactory implements TaskFactory, NodeProvider {
+public class DefaultTaskFactory implements TaskFactory<NodeWithMetadata>, NodeProvider {
 
   public static final String NAME = "default";
 
@@ -69,7 +68,7 @@ public class DefaultTaskFactory implements TaskFactory, NodeProvider {
   }
 
   @Override
-  public Task newInstance(FragmentEventContext eventContext) {
+  public Task<NodeWithMetadata> newInstance(FragmentEventContext eventContext) {
     Fragment fragment = eventContext.getFragmentEvent().getFragment();
     String taskKey = taskFactoryConfig.getTaskNameKey();
     String taskName = fragment.getConfiguration().getString(taskKey);
@@ -77,8 +76,8 @@ public class DefaultTaskFactory implements TaskFactory, NodeProvider {
     Map<String, GraphNodeOptions> tasks = taskFactoryConfig.getTasks();
     return Optional.ofNullable(tasks.get(taskName))
         .map(rootGraphNodeOptions -> {
-          Node rootNode = initNode(rootGraphNodeOptions);
-          return new Task(taskName, rootNode);
+          NodeWithMetadata rootNode = initNode(rootGraphNodeOptions);
+          return new Task<>(taskName, rootNode);
         })
         .orElseThrow(() -> new ConfigurationException("Task [" + taskName + "] not configured!"));
   }

--- a/handler/core/src/main/java/io/knotx/fragments/task/factory/NodeProvider.java
+++ b/handler/core/src/main/java/io/knotx/fragments/task/factory/NodeProvider.java
@@ -15,13 +15,13 @@
  */
 package io.knotx.fragments.task.factory;
 
-import io.knotx.fragments.engine.graph.Node;
+import io.knotx.fragments.task.factory.node.NodeWithMetadata;
 
 /**
  * Inits node based on node options.
  */
 public interface NodeProvider {
 
-  Node initNode(GraphNodeOptions nodeOptions);
+  NodeWithMetadata initNode(GraphNodeOptions nodeOptions);
 
 }

--- a/handler/core/src/main/java/io/knotx/fragments/task/factory/node/CompositeNodeWithMetadata.java
+++ b/handler/core/src/main/java/io/knotx/fragments/task/factory/node/CompositeNodeWithMetadata.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2019 Knot.x Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.knotx.fragments.task.factory.node;
+
+import static io.knotx.fragments.handler.api.domain.FragmentResult.ERROR_TRANSITION;
+import static io.knotx.fragments.handler.api.domain.FragmentResult.SUCCESS_TRANSITION;
+
+import io.knotx.fragments.engine.graph.CompositeNode;
+import io.vertx.core.json.JsonObject;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+public class CompositeNodeWithMetadata implements CompositeNode, NodeWithMetadata {
+
+  private final String id;
+
+  private final List<NodeWithMetadata> nodes;
+
+  private final Map<String, NodeWithMetadata> edges;
+
+  private final JsonObject metadata = new JsonObject();
+
+  public CompositeNodeWithMetadata(String id, List<NodeWithMetadata> nodes,
+      Map<String, NodeWithMetadata> edges) {
+    this.id = id;
+    this.nodes = nodes;
+    this.edges = edges;
+  }
+
+  @Override
+  public String getId() {
+    return id;
+  }
+
+  @Override
+  public Optional<NodeWithMetadata> next(String transition) {
+    return filter(transition).map(edges::get);
+  }
+
+  @Override
+  public List<NodeWithMetadata> getNodes() {
+    return nodes;
+  }
+
+  @Override
+  public JsonObject getData() {
+    metadata
+        .put("id", id)
+        .put("type", "composite")
+        .put("subtasks", nodes.stream().map(NodeWithMetadata::getData).collect(Collectors.toList()))
+        .put("label", "some label")
+        .put("on", JsonObject.mapFrom(edges.entrySet().stream()
+            .collect(Collectors.toMap(Entry::getKey, entry -> entry.getValue().getData()))));
+    return metadata;
+  }
+
+  private Optional<String> filter(String transition) {
+    return ERROR_TRANSITION.equals(transition) || SUCCESS_TRANSITION.equals(transition)
+          ? Optional.of(transition) : Optional.empty();
+  }
+}

--- a/handler/core/src/main/java/io/knotx/fragments/task/factory/node/MissingNode.java
+++ b/handler/core/src/main/java/io/knotx/fragments/task/factory/node/MissingNode.java
@@ -1,0 +1,30 @@
+package io.knotx.fragments.task.factory.node;
+
+import io.knotx.fragments.engine.graph.Node;
+import io.knotx.fragments.engine.graph.NodeType;
+import io.vertx.core.json.JsonObject;
+import java.util.Optional;
+
+public class MissingNode extends NodeWithMetadata {
+
+  @Override
+  public JsonObject generateMetadata() {
+    return new JsonObject()
+        .put("status", "missing");
+  }
+
+  @Override
+  public String getId() {
+    return null;
+  }
+
+  @Override
+  public <T extends Node> Optional<T> next(String transition) {
+    return Optional.empty();
+  }
+
+  @Override
+  public NodeType getType() {
+    return null;
+  }
+}

--- a/handler/core/src/main/java/io/knotx/fragments/task/factory/node/NodeFactory.java
+++ b/handler/core/src/main/java/io/knotx/fragments/task/factory/node/NodeFactory.java
@@ -55,6 +55,6 @@ public interface NodeFactory {
    * @param nodeProvider - node provider if the current node contains others
    * @return node instance
    */
-  Node initNode(GraphNodeOptions nodeOptions, Map<String, Node> edges, NodeProvider nodeProvider);
+  NodeWithMetadata initNode(GraphNodeOptions nodeOptions, Map<String, NodeWithMetadata> edges, NodeProvider nodeProvider);
 
 }

--- a/handler/core/src/main/java/io/knotx/fragments/task/factory/node/NodeWithMetadata.java
+++ b/handler/core/src/main/java/io/knotx/fragments/task/factory/node/NodeWithMetadata.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2019 Knot.x Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.knotx.fragments.task.factory.node;
 
 import io.knotx.fragments.engine.graph.Node;

--- a/handler/core/src/main/java/io/knotx/fragments/task/factory/node/NodeWithMetadata.java
+++ b/handler/core/src/main/java/io/knotx/fragments/task/factory/node/NodeWithMetadata.java
@@ -1,0 +1,10 @@
+package io.knotx.fragments.task.factory.node;
+
+import io.knotx.fragments.engine.graph.Node;
+import io.vertx.core.json.JsonObject;
+
+public interface NodeWithMetadata extends Node {
+
+  JsonObject getData();
+
+}

--- a/handler/core/src/main/java/io/knotx/fragments/task/factory/node/SingleNodeWithMetadata.java
+++ b/handler/core/src/main/java/io/knotx/fragments/task/factory/node/SingleNodeWithMetadata.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (C) 2019 Knot.x Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.knotx.fragments.task.factory.node;
+
+import io.knotx.fragments.engine.graph.SingleNode;
+import io.knotx.fragments.handler.api.Action;
+import io.knotx.fragments.handler.api.domain.FragmentContext;
+import io.knotx.fragments.handler.api.domain.FragmentResult;
+import io.reactivex.Single;
+import io.vertx.core.json.JsonObject;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public class SingleNodeWithMetadata implements SingleNode, NodeWithMetadata {
+
+  private final String id;
+
+  private final Action action;
+
+  private final Map<String, NodeWithMetadata> edges;
+
+  private final String factory;
+
+  private final JsonObject metadata = new JsonObject();
+
+  public SingleNodeWithMetadata(String id, Action action,
+      Map<String, NodeWithMetadata> edges, String factory) {
+    this.id = id;
+    this.action = action;
+    this.edges = edges;
+    this.factory = factory;
+  }
+
+  @Override
+  public Single<FragmentResult> execute(FragmentContext fragmentContext) {
+    return toRxFunction(action).apply(fragmentContext)
+        .doOnSuccess(fragmentResult -> metadata
+            .put("response", new JsonObject()
+                .put("transition", fragmentResult.getTransition())
+                .put("invocations", fragmentResult.getNodeLog())));
+  }
+
+  @Override
+  public String getId() {
+    return id;
+  }
+
+  @Override
+  public Optional<NodeWithMetadata> next(String transition) {
+    return Optional.ofNullable(edges.get(transition));
+  }
+
+  @Override
+  public JsonObject getData() {
+    metadata
+        .put("id", id)
+        .put("type", "single")
+        .put("operation", new JsonObject()
+            .put("type", "action")
+            .put("factory", factory))
+        .put("label", "some label")
+        .put("on", JsonObject.mapFrom(edges.entrySet().stream()
+            .collect(Collectors.toMap(Entry::getKey, entry -> entry.getValue().getData()))));
+    determineStatus();
+    return metadata;
+  }
+
+  private void determineStatus() {
+    if (!metadata.containsKey("status")) {
+      String status;
+      if (!metadata.containsKey("response")) {
+        status = "unprocessed";
+      } else {
+        switch (metadata.getJsonObject("response").getString("transition")) {
+          case FragmentResult.SUCCESS_TRANSITION:
+            status = "success";
+            break;
+          case FragmentResult.ERROR_TRANSITION:
+            status = "error";
+            break;
+          default:
+            status = "other";
+        }
+      }
+      metadata.put("status", status);
+    }
+  }
+
+  private Function<FragmentContext, Single<FragmentResult>> toRxFunction(
+      Action action) {
+    io.knotx.fragments.handler.reactivex.api.Action rxAction = io.knotx.fragments.handler.reactivex.api.Action
+        .newInstance(action);
+    return rxAction::rxApply;
+  }
+}

--- a/handler/core/src/main/java/io/knotx/fragments/task/factory/node/action/ActionNodeFactory.java
+++ b/handler/core/src/main/java/io/knotx/fragments/task/factory/node/action/ActionNodeFactory.java
@@ -15,29 +15,24 @@
  */
 package io.knotx.fragments.task.factory.node.action;
 
-import io.knotx.fragments.engine.graph.Node;
-import io.knotx.fragments.engine.graph.SingleNode;
 import io.knotx.fragments.handler.api.Action;
 import io.knotx.fragments.handler.api.ActionFactory;
-import io.knotx.fragments.handler.api.domain.FragmentContext;
-import io.knotx.fragments.handler.api.domain.FragmentResult;
+import io.knotx.fragments.task.factory.GraphNodeOptions;
 import io.knotx.fragments.task.factory.NodeProvider;
 import io.knotx.fragments.task.factory.node.NodeFactory;
-import io.knotx.fragments.task.factory.GraphNodeOptions;
 import io.knotx.fragments.task.factory.node.NodeWithMetadata;
-import io.reactivex.Single;
+import io.knotx.fragments.task.factory.node.SingleNodeWithMetadata;
 import io.vertx.core.json.JsonObject;
 import io.vertx.reactivex.core.Vertx;
 import java.util.Iterator;
 import java.util.Map;
-import java.util.Optional;
 import java.util.ServiceLoader;
-import java.util.function.Function;
 import java.util.function.Supplier;
 
 public class ActionNodeFactory implements NodeFactory {
 
   public static final String NAME = "action";
+
   private ActionProvider actionProvider;
 
   @Override
@@ -58,7 +53,7 @@ public class ActionNodeFactory implements NodeFactory {
     ActionNodeConfig config = new ActionNodeConfig(nodeOptions.getNode().getConfig());
     Action action = actionProvider.get(config.getAction()).orElseThrow(
         () -> new ActionNotFoundException(config.getAction()));
-    return new SingleNodeWithMetadata(config.getAction(), action, edges);
+    return new SingleNodeWithMetadata(config.getAction(), action, edges, nodeOptions.getNode().getFactory());
   }
 
   private Supplier<Iterator<ActionFactory>> supplyFactories() {
@@ -69,44 +64,4 @@ public class ActionNodeFactory implements NodeFactory {
     };
   }
 
-  class SingleNodeWithMetadata implements SingleNode, NodeWithMetadata {
-
-    private final String id;
-    private final Action action;
-    private final Map<String, NodeWithMetadata> edges;
-
-    public SingleNodeWithMetadata(String id, Action action,
-        Map<String, NodeWithMetadata> edges) {
-      this.id = id;
-      this.action = action;
-      this.edges = edges;
-    }
-
-    @Override
-    public Single<FragmentResult> execute(FragmentContext fragmentContext) {
-      return toRxFunction(action).apply(fragmentContext);
-    }
-
-    @Override
-    public String getId() {
-      return id;
-    }
-
-    @Override
-    public Optional<NodeWithMetadata> next(String transition) {
-      return Optional.ofNullable(edges.get(transition));
-    }
-
-    @Override
-    public JsonObject getData() {
-      return new JsonObject().put("afadfsdf","fdsfsdfsd");
-    }
-
-    private Function<FragmentContext, Single<FragmentResult>> toRxFunction(
-        Action action) {
-      io.knotx.fragments.handler.reactivex.api.Action rxAction = io.knotx.fragments.handler.reactivex.api.Action
-          .newInstance(action);
-      return rxAction::rxApply;
-    }
-  }
 }

--- a/handler/core/src/main/java/io/knotx/fragments/task/factory/node/subtasks/SubtasksNodeFactory.java
+++ b/handler/core/src/main/java/io/knotx/fragments/task/factory/node/subtasks/SubtasksNodeFactory.java
@@ -15,21 +15,16 @@
  */
 package io.knotx.fragments.task.factory.node.subtasks;
 
-import static io.knotx.fragments.handler.api.domain.FragmentResult.ERROR_TRANSITION;
-import static io.knotx.fragments.handler.api.domain.FragmentResult.SUCCESS_TRANSITION;
-
-import io.knotx.fragments.engine.graph.CompositeNode;
-import io.knotx.fragments.engine.graph.Node;
 import io.knotx.fragments.task.factory.NodeProvider;
+import io.knotx.fragments.task.factory.node.CompositeNodeWithMetadata;
 import io.knotx.fragments.task.factory.node.NodeFactory;
 import io.knotx.fragments.task.factory.GraphNodeOptions;
+import io.knotx.fragments.task.factory.node.NodeWithMetadata;
 import io.vertx.core.json.JsonObject;
 import io.vertx.reactivex.core.Vertx;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.stream.Collectors;
-import org.apache.commons.lang3.StringUtils;
 
 public class SubtasksNodeFactory implements NodeFactory {
 
@@ -48,33 +43,13 @@ public class SubtasksNodeFactory implements NodeFactory {
   }
 
   @Override
-  public Node initNode(GraphNodeOptions nodeOptions, Map<String, Node> edges,
+  public NodeWithMetadata initNode(GraphNodeOptions nodeOptions, Map<String, NodeWithMetadata> edges,
       NodeProvider nodeProvider) {
     SubtasksNodeConfig config = new SubtasksNodeConfig(nodeOptions.getNode().getConfig());
-    List<Node> nodes = config.getSubtasks().stream()
+    List<NodeWithMetadata> nodes = config.getSubtasks().stream()
         .map(nodeProvider::initNode)
         .collect(Collectors.toList());
-    return new CompositeNode() {
-      @Override
-      public String getId() {
-        return getNodeId();
-      }
-
-      @Override
-      public Optional<Node> next(String transition) {
-        return filter(transition).map(edges::get);
-      }
-
-      @Override
-      public List<Node> getNodes() {
-        return nodes;
-      }
-
-      private Optional<String> filter(String transition) {
-        return Optional.of(transition)
-            .filter(tr -> StringUtils.equalsAny(tr, ERROR_TRANSITION, SUCCESS_TRANSITION));
-      }
-    };
+    return new CompositeNodeWithMetadata(getNodeId(), nodes, edges);
   }
 
   private String getNodeId() {

--- a/handler/core/src/test/java/io/knotx/fragments/handler/consumer/FragmentHtmlBodyWriterFactoryTest.java
+++ b/handler/core/src/test/java/io/knotx/fragments/handler/consumer/FragmentHtmlBodyWriterFactoryTest.java
@@ -23,28 +23,59 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import io.knotx.fragments.api.Fragment;
+import io.knotx.fragments.engine.EventLog;
+import io.knotx.fragments.engine.EventLogEntry;
 import io.knotx.fragments.engine.FragmentEvent;
+import io.knotx.fragments.engine.Task;
+import io.knotx.fragments.handler.api.Action;
+import io.knotx.fragments.handler.api.domain.FragmentContext;
+import io.knotx.fragments.handler.api.domain.FragmentResult;
+import io.knotx.fragments.task.TasksWithFragmentEvents;
+import io.knotx.fragments.task.factory.node.NodeWithMetadata;
+import io.knotx.fragments.task.factory.node.SingleNodeWithMetadata;
 import io.knotx.server.api.context.ClientRequest;
+import io.vertx.core.Future;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.reactivex.core.MultiMap;
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 class FragmentHtmlBodyWriterFactoryTest {
 
   public static final String EXPECTED_FRAGMENT_TYPE = "snippet";
+
   public static final String EXPECTED_HEADER = "x-knotx-debug";
+
   public static final String EXPECTED_PARAM = "debug";
+
+  public static final FragmentContext DUMMY_FRAGMENT_CONTEXT = new FragmentContext(new Fragment("fragment",
+      new JsonObject(), ""), new ClientRequest());
+
   private static final String PARAM_OPTION = "param";
+
+  public static final FragmentEventsConsumer CONFIGURED_FACTORY = new FragmentHtmlBodyWriterFactory().create(new JsonObject()
+      .put(FRAGMENT_TYPES_OPTIONS, new JsonArray().add(EXPECTED_FRAGMENT_TYPE))
+      .put(CONDITION_OPTION, new JsonObject().put(PARAM_OPTION, EXPECTED_PARAM)));
+
+  private static final Action DUMMY_ACTION = (fragmentContext, resultHandler) -> {
+  };
 
   @Test
   @DisplayName("Expect fragment is not modified when condition not configured")
   void expectFragmentNotModifiedWhenConditionNotConfigured() {
     // given
+    Task<NodeWithMetadata> task = new Task<>("testTask");
     FragmentEvent original = new FragmentEvent(
         new Fragment(EXPECTED_FRAGMENT_TYPE, new JsonObject(),
             "{ \"body\": \"<div>body</div>\" }"));
@@ -54,7 +85,7 @@ class FragmentHtmlBodyWriterFactoryTest {
     FragmentEventsConsumer tested = new FragmentHtmlBodyWriterFactory()
         .create(new JsonObject().put(FRAGMENT_TYPES_OPTIONS, new JsonArray().add(
             EXPECTED_FRAGMENT_TYPE)));
-    tested.accept(new ClientRequest(), ImmutableList.of(original));
+    tested.accept(new ClientRequest(), new TasksWithFragmentEvents(ImmutableList.of(task), ImmutableList.of(original)));
 
     // then
     assertEquals(copy, original);
@@ -64,6 +95,7 @@ class FragmentHtmlBodyWriterFactoryTest {
   @DisplayName("Expect fragment is not modified when supported fragments types not configured.")
   void expectFragmentNotModifiedWhenSupportedTypesNotConfigured() {
     // given
+    Task<NodeWithMetadata> task = new Task<>("testTask");
     FragmentEvent original = new FragmentEvent(
         new Fragment(EXPECTED_FRAGMENT_TYPE, new JsonObject(),
             "{ \"body\": \"<div>body</div>\" }"));
@@ -75,7 +107,7 @@ class FragmentHtmlBodyWriterFactoryTest {
             .put(CONDITION_OPTION, new JsonObject().put(HEADER_OPTION, EXPECTED_HEADER)));
     tested.accept(new ClientRequest()
             .setHeaders(MultiMap.caseInsensitiveMultiMap().add(EXPECTED_HEADER, "true")),
-        ImmutableList.of(original));
+        new TasksWithFragmentEvents(ImmutableList.of(task), ImmutableList.of(original)));
 
     // then
     assertEquals(copy, original);
@@ -85,6 +117,7 @@ class FragmentHtmlBodyWriterFactoryTest {
   @DisplayName("Expect fragment is not modified when supported fragments does not contain fragment type.")
   void expectFragmentNotModifiedWhenOtherSupportedTypeConfigured() {
     // given
+    Task<NodeWithMetadata> task = new Task<>("testTask");
     FragmentEvent original = new FragmentEvent(new Fragment("json", new JsonObject(),
         "{ \"body\": \"<div>body</div>\" }"));
     FragmentEvent copy = new FragmentEvent(original.toJson());
@@ -95,7 +128,7 @@ class FragmentHtmlBodyWriterFactoryTest {
         .put(CONDITION_OPTION, new JsonObject().put(HEADER_OPTION, EXPECTED_HEADER)));
     tested.accept(new ClientRequest()
             .setHeaders(MultiMap.caseInsensitiveMultiMap().add(EXPECTED_HEADER, "true")),
-        ImmutableList.of(original));
+        new TasksWithFragmentEvents(ImmutableList.of(task), ImmutableList.of(original)));
 
     // then
     assertEquals(copy, original);
@@ -105,6 +138,7 @@ class FragmentHtmlBodyWriterFactoryTest {
   @DisplayName("Expect fragment is modified when header condition and supported type configured.")
   void expectFragmentBodyModifiedWhenHeaderConditionConfigured() {
     // given
+    Task<NodeWithMetadata> task = new Task<>("testTask");
     FragmentEvent original = new FragmentEvent(
         new Fragment(EXPECTED_FRAGMENT_TYPE, new JsonObject(),
             "{ \"body\": \"<div>body</div>\" }"));
@@ -116,7 +150,7 @@ class FragmentHtmlBodyWriterFactoryTest {
         .put(CONDITION_OPTION, new JsonObject().put(HEADER_OPTION, EXPECTED_HEADER)));
     tested.accept(new ClientRequest()
             .setHeaders(MultiMap.caseInsensitiveMultiMap().add(EXPECTED_HEADER, "true")),
-        ImmutableList.of(original));
+        new TasksWithFragmentEvents(ImmutableList.of(task), ImmutableList.of(original)));
 
     // then
     // then
@@ -127,20 +161,17 @@ class FragmentHtmlBodyWriterFactoryTest {
   @DisplayName("Expect fragment is modified when param condition and supported type configured.")
   void expectFragmentBodyModifiedWhenParamConditionConfigured() {
     // given
+    Task<NodeWithMetadata> task = new Task<>("testTask");
     FragmentEvent original = new FragmentEvent(
         new Fragment(EXPECTED_FRAGMENT_TYPE, new JsonObject(),
             "{ \"body\": \"<div>body</div>\" }"));
     FragmentEvent copy = new FragmentEvent(original.toJson());
 
     // when
-    FragmentEventsConsumer tested = new FragmentHtmlBodyWriterFactory().create(new JsonObject()
-        .put(FRAGMENT_TYPES_OPTIONS, new JsonArray().add(EXPECTED_FRAGMENT_TYPE))
-        .put(CONDITION_OPTION, new JsonObject().put(PARAM_OPTION, EXPECTED_PARAM)));
-    tested.accept(new ClientRequest()
+    CONFIGURED_FACTORY.accept(new ClientRequest()
             .setParams(MultiMap.caseInsensitiveMultiMap().add(EXPECTED_PARAM, "true")),
-        ImmutableList.of(original));
+        new TasksWithFragmentEvents(ImmutableList.of(task), ImmutableList.of(original)));
 
-    // then
     // then
     assertNotEquals(copy, original);
   }
@@ -150,15 +181,13 @@ class FragmentHtmlBodyWriterFactoryTest {
   void expectFragmentBodyWrappedByFragmentId() {
     // given
     String body = "<div>body</div>";
+    Task<NodeWithMetadata> task = new Task<>("testTask");
     FragmentEvent event = new FragmentEvent(new Fragment("snippet", new JsonObject(), body));
 
     // when
-    FragmentEventsConsumer tested = new FragmentHtmlBodyWriterFactory().create(new JsonObject()
-        .put(FRAGMENT_TYPES_OPTIONS, new JsonArray().add(EXPECTED_FRAGMENT_TYPE))
-        .put(CONDITION_OPTION, new JsonObject().put(PARAM_OPTION, EXPECTED_PARAM)));
-    tested.accept(new ClientRequest()
+    CONFIGURED_FACTORY.accept(new ClientRequest()
             .setParams(MultiMap.caseInsensitiveMultiMap().add(EXPECTED_PARAM, "true")),
-        ImmutableList.of(event));
+        new TasksWithFragmentEvents(ImmutableList.of(task), ImmutableList.of(event)));
 
     // then
     assertTrue(event.getFragment().getBody()
@@ -171,21 +200,19 @@ class FragmentHtmlBodyWriterFactoryTest {
   @DisplayName("Expect fragment body contains debug script when fragment type configured.")
   void expectFragmentBodyContainsDebugScript() {
     //given
+    Task<NodeWithMetadata> task = new Task<>("testTask");
     String body = "<div>body</div>";
     FragmentEvent event = new FragmentEvent(new Fragment("snippet", new JsonObject(), body));
     JsonObject eventData = event.toJson();
 
-    String scriptRegexp = "<script data-knotx-id=\"" + event.getFragment().getId()
+    String scriptRegexp = "<script data-knotx-debug=\"log\" data-knotx-id=\"" + event.getFragment().getId()
         + "\" type=\"application/json\">(?<fragmentEventJson>.*?)</script>";
     Pattern scriptPattern = Pattern.compile(scriptRegexp, Pattern.DOTALL);
 
     // when
-    FragmentEventsConsumer tested = new FragmentHtmlBodyWriterFactory().create(new JsonObject()
-        .put(FRAGMENT_TYPES_OPTIONS, new JsonArray().add(EXPECTED_FRAGMENT_TYPE))
-        .put(CONDITION_OPTION, new JsonObject().put(PARAM_OPTION, EXPECTED_PARAM)));
-    tested.accept(new ClientRequest()
+    CONFIGURED_FACTORY.accept(new ClientRequest()
             .setParams(MultiMap.caseInsensitiveMultiMap().add(EXPECTED_PARAM, "true")),
-        ImmutableList.of(event));
+        new TasksWithFragmentEvents(ImmutableList.of(task), ImmutableList.of(event)));
 
     // then
     Matcher matcher = scriptPattern.matcher(event.getFragment().getBody());
@@ -197,23 +224,69 @@ class FragmentHtmlBodyWriterFactoryTest {
   @DisplayName("Expect debug script is first HTML tag.")
   void expectDebugScriptAfterComment() {
     //given
+    Task<NodeWithMetadata> task = new Task<>("testTask");
     String body = "<div>body</div>";
     FragmentEvent event = new FragmentEvent(new Fragment("snippet", new JsonObject(), body));
 
     // when
-    FragmentEventsConsumer tested = new FragmentHtmlBodyWriterFactory().create(new JsonObject()
-        .put(FRAGMENT_TYPES_OPTIONS, new JsonArray().add(EXPECTED_FRAGMENT_TYPE))
-        .put(CONDITION_OPTION, new JsonObject().put(PARAM_OPTION, EXPECTED_PARAM)));
-    tested.accept(new ClientRequest()
+    CONFIGURED_FACTORY.accept(new ClientRequest()
             .setParams(MultiMap.caseInsensitiveMultiMap().add(EXPECTED_PARAM, "true")),
-        ImmutableList.of(event));
+        new TasksWithFragmentEvents(ImmutableList.of(task), ImmutableList.of(event)));
 
     // then
     String bodyWithoutComments = event.getFragment().getBody()
         .replaceAll("<!-- data-knotx-id=\"" + event.getFragment().getId() + "\" -->", "");
     assertTrue(
-        bodyWithoutComments.startsWith("<script data-knotx-id=\"" + event.getFragment().getId()
+        bodyWithoutComments.startsWith("<script data-knotx-debug=\"log\" data-knotx-id=\"" + event.getFragment().getId()
             + "\" type=\"application/json\">"));
   }
 
+  @Test
+  @DisplayName("Expect fragment body contains debug script when fragment type configured.")
+  void expectFragmentBodyContainsDebugGraphData() throws IOException {
+    //given
+    SingleNodeWithMetadata childNode = new SingleNodeWithMetadata("childNode",
+        transitTo("_success", new JsonObject()), new HashMap<>(), "someFactory");
+    SingleNodeWithMetadata rootNode = new SingleNodeWithMetadata("someNode",
+        transitTo("_success", new JsonObject().put("sample", "node Log")), ImmutableMap.of("_success", childNode),
+        "someOtherFactory");
+    Task<NodeWithMetadata> task = new Task<>("testTask", rootNode);
+    String body = "<div>body</div>";
+    Fragment fragment = new Fragment("snippet", new JsonObject(), body);
+    FragmentEvent event = new FragmentEvent(fragment);
+    JsonObject expected = readFromResources("handler/consumer/graph/twoNodesSuccess.json");
+
+    // when
+    rootNode.execute(new FragmentContext(fragment, new ClientRequest())).blockingGet();
+    childNode.execute(new FragmentContext(fragment, new ClientRequest())).blockingGet();
+    CONFIGURED_FACTORY.accept(new ClientRequest()
+            .setParams(MultiMap.caseInsensitiveMultiMap().add(EXPECTED_PARAM, "true")),
+        new TasksWithFragmentEvents(ImmutableList.of(task), ImmutableList.of(event)));
+
+    // then
+    JsonObject actual = retrieveGraphData(event);
+    assertEquals(expected, actual);
+  }
+
+  private JsonObject readFromResources(String fileName) throws IOException {
+    return new JsonObject(IOUtils
+        .toString(getClass().getClassLoader().getResourceAsStream(fileName), StandardCharsets.UTF_8));
+  }
+
+  private static JsonObject retrieveGraphData(FragmentEvent event) {
+    String scriptRegexp = "<script data-knotx-debug=\"graph\" data-knotx-id=\"" + event.getFragment().getId()
+        + "\" type=\"application/json\">(?<fragmentEventJson>.*?)</script>";
+    Pattern scriptPattern = Pattern.compile(scriptRegexp, Pattern.DOTALL);
+    Matcher matcher = scriptPattern.matcher(event.getFragment().getBody());
+    assertTrue(matcher.find());
+    String fragmentEventJson = matcher.group("fragmentEventJson");
+    return new JsonObject(fragmentEventJson);
+  }
+
+  private static Action transitTo(String transition, JsonObject nodeLog) {
+    return (fragmentContext, resultHandler) -> {
+      Future.succeededFuture(new FragmentResult(fragmentContext.getFragment(), transition, nodeLog))
+          .setHandler(resultHandler);
+    };
+  }
 }

--- a/handler/core/src/test/java/io/knotx/fragments/task/factory/DefaultTaskFactoryTest.java
+++ b/handler/core/src/test/java/io/knotx/fragments/task/factory/DefaultTaskFactoryTest.java
@@ -29,6 +29,7 @@ import io.knotx.fragments.engine.graph.CompositeNode;
 import io.knotx.fragments.engine.graph.Node;
 import io.knotx.fragments.engine.graph.SingleNode;
 import io.knotx.fragments.task.factory.node.NodeFactoryOptions;
+import io.knotx.fragments.task.factory.node.NodeWithMetadata;
 import io.knotx.fragments.task.factory.node.action.ActionNodeFactory;
 import io.knotx.fragments.task.factory.node.action.ActionNodeFactoryConfig;
 import io.knotx.fragments.task.factory.node.subtasks.SubtasksNodeFactory;
@@ -220,7 +221,7 @@ class DefaultTaskFactoryTest {
             new GraphNodeOptions("B", NO_TRANSITIONS)));
 
     // when
-    Task task = getTask(graph, options, vertx);
+    Task<NodeWithMetadata> task = getTask(graph, options, vertx);
 
     // then
     assertEquals(TASK_NAME, task.getName());
@@ -250,7 +251,7 @@ class DefaultTaskFactoryTest {
     );
 
     // when
-    Task task = getTask(graph, options, vertx);
+    Task<NodeWithMetadata> task = getTask(graph, options, vertx);
 
     // then
     assertEquals(TASK_NAME, task.getName());
@@ -272,7 +273,7 @@ class DefaultTaskFactoryTest {
     assertEquals("A", node.getId());
   }
 
-  private Task getTask(GraphNodeOptions graph, JsonObject actionNodeConfig, Vertx vertx) {
+  private Task<NodeWithMetadata> getTask(GraphNodeOptions graph, JsonObject actionNodeConfig, Vertx vertx) {
     DefaultTaskFactoryConfig taskFactoryConfig = createTaskFactoryConfig(graph, actionNodeConfig);
     return new DefaultTaskFactory().configure(taskFactoryConfig.toJson(), vertx)
         .newInstance(SAMPLE_FRAGMENT_EVENT);

--- a/handler/core/src/test/java/io/knotx/fragments/task/factory/node/StubNode.java
+++ b/handler/core/src/test/java/io/knotx/fragments/task/factory/node/StubNode.java
@@ -17,9 +17,10 @@ package io.knotx.fragments.task.factory.node;
 
 import io.knotx.fragments.engine.graph.Node;
 import io.knotx.fragments.engine.graph.NodeType;
+import io.vertx.core.json.JsonObject;
 import java.util.Optional;
 
-public class StubNode implements Node {
+public class StubNode extends NodeWithMetadata {
 
   private String id;
 
@@ -40,5 +41,10 @@ public class StubNode implements Node {
   @Override
   public NodeType getType() {
     return NodeType.SINGLE;
+  }
+
+  @Override
+  public JsonObject generateMetadata() {
+    return new JsonObject();
   }
 }

--- a/handler/core/src/test/java/io/knotx/fragments/task/factory/node/subtasks/SubtasksNodeFactoryTest.java
+++ b/handler/core/src/test/java/io/knotx/fragments/task/factory/node/subtasks/SubtasksNodeFactoryTest.java
@@ -31,6 +31,7 @@ import io.knotx.fragments.engine.graph.CompositeNode;
 import io.knotx.fragments.engine.graph.Node;
 import io.knotx.fragments.task.factory.NodeProvider;
 import io.knotx.fragments.task.factory.node.NodeOptions;
+import io.knotx.fragments.task.factory.node.NodeWithMetadata;
 import io.knotx.fragments.task.factory.node.StubNode;
 import io.knotx.fragments.task.factory.GraphNodeOptions;
 import io.vertx.core.json.JsonObject;
@@ -97,7 +98,7 @@ class SubtasksNodeFactoryTest {
     NodeProvider nodeProvider = mock(NodeProvider.class);
     when(nodeProvider.initNode(any())).thenReturn(new StubNode("A"));
 
-    Map<String, Node> transitionsToNodes = new HashMap<>();
+    Map<String, NodeWithMetadata> transitionsToNodes = new HashMap<>();
     transitionsToNodes.put(SUCCESS_TRANSITION, new StubNode("B"));
     transitionsToNodes.put(ERROR_TRANSITION, new StubNode("C"));
     transitionsToNodes.put("otherTransition", new StubNode("D"));

--- a/handler/core/src/test/resources/handler/consumer/graph/compositeNode.json
+++ b/handler/core/src/test/resources/handler/consumer/graph/compositeNode.json
@@ -1,0 +1,46 @@
+{
+  "response": {
+    "transition": "_success"
+  },
+  "id": "rootNode",
+  "type": "composite",
+  "subtasks": [
+    {
+      "id": "successChild",
+      "type": "single",
+      "operation": {
+        "type": "action",
+        "factory": "someFactory"
+      },
+      "label": "some label",
+      "on": {},
+      "status": "unprocessed"
+    },
+    {
+      "response": {
+        "transition": "someothercustomtransition",
+        "invocations": {}
+      },
+      "id": "customChild",
+      "type": "single",
+      "operation": {
+        "type": "action",
+        "factory": "someFactory"
+      },
+      "label": "some label",
+      "on": {
+        "someothercustomtransition": {
+          "status": "missing"
+        }
+      },
+      "status": "other"
+    }
+  ],
+  "label": "some label",
+  "on": {
+    "_success": {
+      "status": "missing"
+    }
+  },
+  "status": "success"
+}

--- a/handler/core/src/test/resources/handler/consumer/graph/singleWithComposite.json
+++ b/handler/core/src/test/resources/handler/consumer/graph/singleWithComposite.json
@@ -1,0 +1,64 @@
+{
+  "response": {
+    "transition": "_success",
+    "invocations": {
+      "sample": "node Log"
+    }
+  },
+  "id": "someNode",
+  "type": "single",
+  "operation": {
+    "type": "action",
+    "factory": "someOtherFactory"
+  },
+  "label": "some label",
+  "on": {
+    "_success": {
+      "response": {
+        "transition": "_success"
+      },
+      "id": "compositeNode",
+      "type": "composite",
+      "subtasks": [
+        {
+          "id": "successChild",
+          "type": "single",
+          "operation": {
+            "type": "action",
+            "factory": "someFactory"
+          },
+          "label": "some label",
+          "on": {},
+          "status": "unprocessed"
+        },
+        {
+          "response": {
+            "transition": "someothercustomtransition",
+            "invocations": {}
+          },
+          "id": "customChild",
+          "type": "single",
+          "operation": {
+            "type": "action",
+            "factory": "someFactory"
+          },
+          "label": "some label",
+          "on": {
+            "someothercustomtransition": {
+              "status": "missing"
+            }
+          },
+          "status": "other"
+        }
+      ],
+      "label": "some label",
+      "on": {
+        "_success": {
+          "status": "missing"
+        }
+      },
+      "status": "success"
+    }
+  },
+  "status": "success"
+}

--- a/handler/core/src/test/resources/handler/consumer/graph/threeNodesCustomTransitions.json
+++ b/handler/core/src/test/resources/handler/consumer/graph/threeNodesCustomTransitions.json
@@ -1,0 +1,48 @@
+{
+  "response": {
+    "transition": "customtransition",
+    "invocations": {
+      "sample": "node Log"
+    }
+  },
+  "id": "someNode",
+  "type": "single",
+  "operation": {
+    "type": "action",
+    "factory": "someOtherFactory"
+  },
+  "label": "some label",
+  "on": {
+    "_success": {
+      "id": "successChild",
+      "type": "single",
+      "operation": {
+        "type": "action",
+        "factory": "someFactory"
+      },
+      "label": "some label",
+      "on": {},
+      "status": "unprocessed"
+    },
+    "customtransition": {
+      "response": {
+        "transition": "someothercustomtransition",
+        "invocations": {}
+      },
+      "id": "customChild",
+      "type": "single",
+      "operation": {
+        "type": "action",
+        "factory": "someFactory"
+      },
+      "label": "some label",
+      "on": {
+        "someothercustomtransition": {
+          "status": "missing"
+        }
+      },
+      "status": "other"
+    }
+  },
+  "status": "other"
+}

--- a/handler/core/src/test/resources/handler/consumer/graph/threeNodesError.json
+++ b/handler/core/src/test/resources/handler/consumer/graph/threeNodesError.json
@@ -1,0 +1,48 @@
+{
+  "response": {
+    "transition": "_error",
+    "invocations": {
+      "sample": "node Log"
+    }
+  },
+  "id": "someNode",
+  "type": "single",
+  "operation": {
+    "type": "action",
+    "factory": "someOtherFactory"
+  },
+  "label": "some label",
+  "on": {
+    "_success": {
+      "id": "successChild",
+      "type": "single",
+      "operation": {
+        "type": "action",
+        "factory": "someFactory"
+      },
+      "label": "some label",
+      "on": {},
+      "status": "unprocessed"
+    },
+    "_error": {
+      "response": {
+        "transition": "_success",
+        "invocations": {}
+      },
+      "id": "failChild",
+      "type": "single",
+      "operation": {
+        "type": "action",
+        "factory": "someFactory"
+      },
+      "label": "some label",
+      "on": {
+        "_success": {
+          "status": "missing"
+        }
+      },
+      "status": "success"
+    }
+  },
+  "status": "error"
+}

--- a/handler/core/src/test/resources/handler/consumer/graph/twoNodesSuccess.json
+++ b/handler/core/src/test/resources/handler/consumer/graph/twoNodesSuccess.json
@@ -1,0 +1,37 @@
+{
+  "response": {
+    "transition": "_success",
+    "invocations": {
+      "sample": "node Log"
+    }
+  },
+  "id": "someNode",
+  "type": "single",
+  "operation": {
+    "type": "action",
+    "factory": "someOtherFactory"
+  },
+  "label": "some label",
+  "on": {
+    "_success": {
+      "response": {
+        "transition": "_success",
+        "invocations": {}
+      },
+      "id": "childNode",
+      "type": "single",
+      "operation": {
+        "type": "action",
+        "factory": "someFactory"
+      },
+      "label": "some label",
+      "on": {
+        "_success": {
+          "status": "missing"
+        }
+      },
+      "status": "success"
+    }
+  },
+  "status": "success"
+}

--- a/handler/engine/src/main/java/io/knotx/fragments/engine/FragmentEventContextTaskAware.java
+++ b/handler/engine/src/main/java/io/knotx/fragments/engine/FragmentEventContextTaskAware.java
@@ -15,18 +15,20 @@
  */
 package io.knotx.fragments.engine;
 
-public class FragmentEventContextTaskAware {
+import io.knotx.fragments.engine.graph.Node;
 
-  private final Task task;
+public class FragmentEventContextTaskAware <T extends Node> {
+
+  private final Task<T> task;
   private final FragmentEventContext fragmentEventContext;
 
-  public FragmentEventContextTaskAware(Task task,
+  public FragmentEventContextTaskAware(Task<T> task,
       FragmentEventContext fragmentEventContext) {
     this.task = task;
     this.fragmentEventContext = fragmentEventContext;
   }
 
-  public Task getTask() {
+  public Task<T> getTask() {
     return task;
   }
 

--- a/handler/engine/src/main/java/io/knotx/fragments/engine/FragmentsEngine.java
+++ b/handler/engine/src/main/java/io/knotx/fragments/engine/FragmentsEngine.java
@@ -33,7 +33,7 @@ import java.util.stream.Collectors;
  * events (fragments) is transformed to single items and processed independently. The inspiration
  * comes from https://github.com/tomaszmichalak/vertx-rx-map-reduce.
  */
-public class FragmentsEngine {
+public class FragmentsEngine <T extends Node> {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(FragmentsEngine.class);
 
@@ -50,7 +50,7 @@ public class FragmentsEngine {
    * @return asynchronous response containing processed list of fragment events returned in the same
    * order as the original list
    */
-  public Single<List<FragmentEvent>> execute(List<FragmentEventContextTaskAware> fragments) {
+  public Single<List<FragmentEvent>> execute(List<FragmentEventContextTaskAware<T>> fragments) {
 
     return Flowable.just(fragments)
         .concatMap(Flowable::fromIterable)
@@ -69,12 +69,12 @@ public class FragmentsEngine {
         .map(this::traceEngineResults);
   }
 
-  private Single<FragmentEvent> startTaskEngine(FragmentEventContextTaskAware fragment, Node rootNode) {
+  private Single<FragmentEvent> startTaskEngine(FragmentEventContextTaskAware<T> fragment, Node rootNode) {
       return taskEngine.start(fragment.getTask().getName(), rootNode, fragment.getFragmentEventContext());
   }
 
   private List<FragmentEvent> incomingOrder(
-      List<FragmentEvent> list, List<FragmentEventContextTaskAware> sourceEvents) {
+      List<FragmentEvent> list, List<FragmentEventContextTaskAware<T>> sourceEvents) {
 
     return sourceEvents.stream()
         .map(event -> event.getFragmentEventContext().getFragmentEvent().getFragment().getId())

--- a/handler/engine/src/main/java/io/knotx/fragments/engine/Task.java
+++ b/handler/engine/src/main/java/io/knotx/fragments/engine/Task.java
@@ -18,21 +18,21 @@ package io.knotx.fragments.engine;
 import io.knotx.fragments.engine.graph.Node;
 import java.util.Optional;
 
-public class Task {
+public class Task <T extends Node> {
 
   private final String name;
-  private final Node rootNode;
+  private final T rootNode;
 
   public Task(String name) {
     this(name, null);
   }
 
-  public Task(String name, Node rootNode) {
+  public Task(String name, T rootNode) {
     this.name = name;
     this.rootNode = rootNode;
   }
 
-  public Optional<Node> getRootNode() {
+  public Optional<T> getRootNode() {
     return Optional.ofNullable(rootNode);
   }
 

--- a/handler/engine/src/main/java/io/knotx/fragments/engine/TaskEngine.java
+++ b/handler/engine/src/main/java/io/knotx/fragments/engine/TaskEngine.java
@@ -76,7 +76,7 @@ class TaskEngine {
 
   private Single<FragmentResult> mapReduce(TaskExecutionContext context) {
     CompositeNode node = (CompositeNode) context.getCurrentNode();
-    return Observable.fromIterable(node.getNodes())
+    return Observable.fromIterable(node.<Node>getNodes())
         .flatMap(graphNode -> processTask(context, graphNode).toObservable())
         .reduce(context, TaskExecutionContext::merge)
         .map(TaskExecutionContext::toFragmentResult);

--- a/handler/engine/src/main/java/io/knotx/fragments/engine/graph/CompositeNode.java
+++ b/handler/engine/src/main/java/io/knotx/fragments/engine/graph/CompositeNode.java
@@ -19,7 +19,7 @@ import java.util.List;
 
 public interface CompositeNode extends Node {
 
-  List<Node> getNodes();
+  <T extends Node> List<T> getNodes();
 
   @Override
   default NodeType getType() {

--- a/handler/engine/src/main/java/io/knotx/fragments/engine/graph/Node.java
+++ b/handler/engine/src/main/java/io/knotx/fragments/engine/graph/Node.java
@@ -21,7 +21,7 @@ public interface Node {
 
   String getId();
 
-  Optional<Node> next(String transition);
+  <T extends Node> Optional<T> next(String transition);
 
   NodeType getType();
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Expose graph data to fragment result

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In order to enable chrome extension to print graph data, the data must be exposed to fragment result

## Screenshots (if appropriate)

## Upgrade notes (if appropriate)
<!-- What changes user have to do in order to migrate from the previous version to the version with this feature -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](/CONTRIBUTING.md#coding-conventions) of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---
I hereby agree to the terms of the Knot.x Contributor License Agreement.
