### PR TITLE
Refactor HttpAction + Cache WebClient and Action

### DIFF
--- a/handler/actions/README.md
+++ b/handler/actions/README.md
@@ -75,7 +75,7 @@ Table below shows the behaviour of HttpAction depending on provided `responseOpt
 
 #### Node log
 HTTP Action adds details about the request, response and occurred errors to [node log](https://github.com/Knotx/knotx-fragments/tree/master/handler/engine#node-log). 
-If the log level is `ERROR`, then only failing situations are logged: exception occurs during processing, response predicate is not valid, or status code is not between 200 and 300. 
+If the log level is `ERROR`, then only failing situations are logged: exception occurs during processing, response predicate is not valid, or status code is between 400 and 600. 
 For the `INFO` log level all items are logged.
 
 Node log is presented as `JSON` and has the following structure:

--- a/handler/actions/docs/asciidoc/dataobjects.adoc
+++ b/handler/actions/docs/asciidoc/dataobjects.adoc
@@ -68,6 +68,7 @@ Sets the HTTP <code>port</code> the external service
 |[[endpointOptions]]`@endpointOptions`|`link:dataobjects.html#EndpointOptions[EndpointOptions]`|+++
 Set the details of the remote http endpoint location.
 +++
+|[[httpMethod]]`@httpMethod`|`String`|-
 |[[logLevel]]`@logLevel`|`String`|+++
 Set level of action logs.
 +++
@@ -77,11 +78,7 @@ Configures the amount of time in milliseconds after which if the request does no
  the timeout. By default it is set to <code>0</code>.
 +++
 |[[responseOptions]]`@responseOptions`|`link:dataobjects.html#ResponseOptions[ResponseOptions]`|-
-|[[webClientOptions]]`@webClientOptions`|`link:dataobjects.html#WebClientOptions[WebClientOptions]`|+++
-Set the <code>WebClientOptions</code> used by the HTTP client to communicate with remote http
- endpoint. See https://vertx.io/docs/vertx-web-client/dataobjects.html#WebClientOptions for the
- details what can be configured.
-+++
+|[[webClientOptions]]`@webClientOptions`|`link:dataobjects.html#WebClientOptions[WebClientOptions]`|-
 |===
 
 [[ResponseOptions]]

--- a/handler/actions/src/main/java/io/knotx/fragments/handler/action/exception/ActionConfigurationException.java
+++ b/handler/actions/src/main/java/io/knotx/fragments/handler/action/exception/ActionConfigurationException.java
@@ -13,26 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.knotx.fragments.handler.action.http;
+package io.knotx.fragments.handler.action.exception;
 
-import io.vertx.reactivex.core.MultiMap;
+import io.knotx.fragments.handler.api.exception.ConfigurationException;
 
-class EndpointRequest {
+public class ActionConfigurationException extends ConfigurationException {
 
-  private final String path;
-  private final MultiMap headers;
-
-  public EndpointRequest(String path, MultiMap headers) {
-    this.path = path;
-    this.headers = headers;
-  }
-
-  public String getPath() {
-    return path;
-  }
-
-  public MultiMap getHeaders() {
-    return headers;
+  public ActionConfigurationException(String actionAlias, String message) {
+    super(actionAlias + ": " + message);
   }
 
 }

--- a/handler/actions/src/main/java/io/knotx/fragments/handler/action/http/EndpointInvoker.java
+++ b/handler/actions/src/main/java/io/knotx/fragments/handler/action/http/EndpointInvoker.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2019 Knot.x Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.knotx.fragments.handler.action.http;
+
+import io.knotx.fragments.handler.action.http.options.HttpActionOptions;
+import io.knotx.fragments.handler.action.http.request.EndpointRequest;
+import io.knotx.fragments.handler.action.http.request.ResponsePredicatesProvider;
+import io.reactivex.Single;
+import io.vertx.core.eventbus.ReplyException;
+import io.vertx.core.eventbus.ReplyFailure;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.reactivex.core.buffer.Buffer;
+import io.vertx.reactivex.ext.web.client.HttpRequest;
+import io.vertx.reactivex.ext.web.client.HttpResponse;
+import io.vertx.reactivex.ext.web.client.WebClient;
+import io.vertx.reactivex.ext.web.client.predicate.ErrorConverter;
+import io.vertx.reactivex.ext.web.client.predicate.ResponsePredicate;
+import java.util.Set;
+
+class EndpointInvoker {
+
+  private static final ResponsePredicate IS_JSON_RESPONSE = createJsonPredicate();
+  private static final String JSON = "JSON";
+
+  private final WebClient webClient;
+  private final HttpActionOptions httpActionOptions;
+  private final ResponsePredicatesProvider predicatesProvider = new ResponsePredicatesProvider();
+  private final boolean isJsonPredicate;
+
+  EndpointInvoker(WebClient webClient, HttpActionOptions httpActionOptions) {
+    this.webClient = webClient;
+    this.httpActionOptions = httpActionOptions;
+    this.isJsonPredicate = httpActionOptions.getResponseOptions().getPredicates().contains(JSON);
+  }
+
+  Single<HttpResponse<Buffer>> invokeEndpoint(EndpointRequest request) {
+    return Single.just(request)
+        .map(this::createHttpRequest)
+        .doOnSuccess(this::addPredicates)
+        .flatMap(HttpRequest::rxSend);
+  }
+
+  private HttpRequest<Buffer> createHttpRequest(EndpointRequest endpointRequest) {
+    return webClient
+        .request(HttpMethod.GET,
+            httpActionOptions.getEndpointOptions().getPort(),
+            httpActionOptions.getEndpointOptions().getDomain(),
+            endpointRequest.getPath())
+        .timeout(httpActionOptions.getRequestTimeoutMs())
+        .putHeaders(endpointRequest.getHeaders());
+  }
+
+  private void addPredicates(HttpRequest<Buffer> request) {
+    if (isJsonPredicate) {
+      request.expect(IS_JSON_RESPONSE);
+    }
+    attachResponsePredicatesToRequest(request,
+        httpActionOptions.getResponseOptions().getPredicates());
+  }
+
+  private void attachResponsePredicatesToRequest(HttpRequest<Buffer> request,
+      Set<String> predicates) {
+    predicates.stream()
+        .filter(p -> !JSON.equals(p))
+        .map(predicatesProvider::fromName)
+        .forEach(request::expect);
+  }
+
+  private static ResponsePredicate createJsonPredicate() {
+    return ResponsePredicate.create(
+        ResponsePredicate.JSON,
+        ErrorConverter.create(result -> {
+          throw new ReplyException(ReplyFailure.RECIPIENT_FAILURE, result.message());
+        })
+    );
+  }
+
+}

--- a/handler/actions/src/main/java/io/knotx/fragments/handler/action/http/HttpAction.java
+++ b/handler/actions/src/main/java/io/knotx/fragments/handler/action/http/HttpAction.java
@@ -15,170 +15,92 @@
  */
 package io.knotx.fragments.handler.action.http;
 
-import static io.knotx.fragments.handler.api.domain.FragmentResult.ERROR_TRANSITION;
-import static io.netty.handler.codec.http.HttpStatusClass.CLIENT_ERROR;
-import static io.netty.handler.codec.http.HttpStatusClass.SERVER_ERROR;
-import static io.netty.handler.codec.http.HttpStatusClass.SUCCESS;
-
-import io.knotx.commons.http.request.AllowedHeadersFilter;
-import io.knotx.commons.http.request.MultiMapCollector;
 import io.knotx.fragments.api.Fragment;
+import io.knotx.fragments.handler.action.http.log.HttpActionLogger;
+import io.knotx.fragments.handler.action.http.options.EndpointOptions;
+import io.knotx.fragments.handler.action.http.options.HttpActionOptions;
+import io.knotx.fragments.handler.action.http.request.EndpointRequestComposer;
+import io.knotx.fragments.handler.action.http.response.EndpointResponse;
+import io.knotx.fragments.handler.action.http.response.EndpointResponseProcessor;
 import io.knotx.fragments.handler.api.Action;
 import io.knotx.fragments.handler.api.actionlog.ActionLogLevel;
-import io.knotx.fragments.handler.api.actionlog.ActionLogger;
 import io.knotx.fragments.handler.api.domain.FragmentContext;
 import io.knotx.fragments.handler.api.domain.FragmentResult;
 import io.knotx.fragments.handler.api.domain.payload.ActionPayload;
-import io.knotx.fragments.handler.api.domain.payload.ActionRequest;
-import io.knotx.server.api.context.ClientRequest;
-import io.knotx.server.common.placeholders.PlaceholdersResolver;
-import io.knotx.server.common.placeholders.SourceDefinitions;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.reactivex.Single;
 import io.reactivex.exceptions.Exceptions;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
-import io.vertx.core.Vertx;
-import io.vertx.core.eventbus.ReplyException;
-import io.vertx.core.eventbus.ReplyFailure;
-import io.vertx.core.http.HttpMethod;
-import io.vertx.core.json.JsonArray;
-import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
-import io.vertx.ext.web.client.predicate.ResponsePredicate;
-import io.vertx.reactivex.core.MultiMap;
-import io.vertx.reactivex.core.buffer.Buffer;
-import io.vertx.reactivex.ext.web.client.HttpRequest;
-import io.vertx.reactivex.ext.web.client.HttpResponse;
 import io.vertx.reactivex.ext.web.client.WebClient;
-import java.io.IOException;
-import java.util.List;
-import java.util.Set;
 import java.util.concurrent.TimeoutException;
-import java.util.regex.Pattern;
-import org.apache.commons.lang3.StringUtils;
 
 public class HttpAction implements Action {
 
-  private static final String HTTP_ACTION_TYPE = "HTTP";
-  public static final String TIMEOUT_TRANSITION = "_timeout";
   private static final Logger LOGGER = LoggerFactory.getLogger(HttpAction.class);
-  private static final String METADATA_HEADERS_KEY = "headers";
-  private static final String METADATA_STATUS_CODE_KEY = "statusCode";
-  private static final String PLACEHOLDER_PREFIX_PAYLOAD = "payload";
-  private static final String PLACEHOLDER_PREFIX_CONFIG = "config";
-  private static final String JSON = "JSON";
-  private static final String APPLICATION_JSON = "application/json";
-  private static final String CONTENT_TYPE = "Content-Type";
-  private static final String RESPONSE = "response";
-  private static final String REQUEST = "request";
-  private static final String RESPONSE_BODY = "responseBody";
-  private final boolean isJsonPredicate;
-  private final boolean isForceJson;
 
-  private final EndpointOptions endpointOptions;
-  private final WebClient webClient;
   private final String actionAlias;
-  private final HttpActionOptions httpActionOptions;
-  private final ResponsePredicatesProvider predicatesProvider;
+  private final String httpMethod;
   private final ActionLogLevel logLevel;
-  private static final ResponsePredicate IS_JSON_RESPONSE = ResponsePredicate
-      .create(ResponsePredicate.JSON, result -> {
-        throw new ReplyException(ReplyFailure.RECIPIENT_FAILURE, result.message());
-      });
+  private final EndpointOptions endpointOptions;
+  private final EndpointRequestComposer requestComposer;
+  private final EndpointInvoker endpointInvoker;
+  private final EndpointResponseProcessor responseProcessor;
 
-  HttpAction(Vertx vertx, HttpActionOptions httpActionOptions, String actionAlias,
-      ActionLogLevel logLevel) {
-    this.httpActionOptions = httpActionOptions;
-    this.webClient = WebClient.create(io.vertx.reactivex.core.Vertx.newInstance(vertx),
-        httpActionOptions.getWebClientOptions());
+  HttpAction(WebClient webClient, HttpActionOptions httpActionOptions, String actionAlias) {
     this.endpointOptions = httpActionOptions.getEndpointOptions();
     this.actionAlias = actionAlias;
-    predicatesProvider = new ResponsePredicatesProvider();
-    this.isJsonPredicate = this.httpActionOptions.getResponseOptions().getPredicates()
-        .contains(JSON);
-    this.isForceJson = httpActionOptions.getResponseOptions().isForceJson();
-    this.logLevel = logLevel;
+    this.logLevel = ActionLogLevel
+        .fromConfig(httpActionOptions.getLogLevel(), ActionLogLevel.ERROR);
+    this.endpointInvoker = new EndpointInvoker(webClient, httpActionOptions);
+    this.requestComposer = new EndpointRequestComposer(endpointOptions);
+    this.responseProcessor = new EndpointResponseProcessor(httpActionOptions.getResponseOptions());
+    this.httpMethod = httpActionOptions.getHttpMethod();
   }
 
   @Override
   public void apply(FragmentContext fragmentContext,
       Handler<AsyncResult<FragmentResult>> resultHandler) {
-    final ActionLogger actionLogger = ActionLogger.create(actionAlias, logLevel);
-    process(fragmentContext, actionLogger)
-        .onErrorReturn(error -> logAndErrorTransition(error, fragmentContext, actionLogger))
+    Single.just(fragmentContext)
+        .flatMap(this::process)
         .map(Future::succeededFuture)
-        .subscribe(future -> future.setHandler(resultHandler));
+        .map(future -> future.setHandler(resultHandler))
+        .subscribe();
   }
 
-  private FragmentResult logAndErrorTransition(Throwable error, FragmentContext fragmentContext,
-      ActionLogger actionLogger) {
-    actionLogger.error(error);
-    return new FragmentResult(fragmentContext.getFragment(), FragmentResult.ERROR_TRANSITION,
-        actionLogger.toLog().toJson());
-  }
-
-  private Single<FragmentResult> process(FragmentContext fragmentContext,
-      ActionLogger actionLogger) {
+  private Single<FragmentResult> process(FragmentContext fragmentContext) {
+    HttpActionLogger httpActionLogger = HttpActionLogger
+        .create(actionAlias, logLevel, endpointOptions, httpMethod);
     return Single.just(fragmentContext)
-        .map(this::createEndpointRequest)
-        .doOnSuccess(request -> logRequest(actionLogger, request))
+        .map(requestComposer::createEndpointRequest)
+        .doOnSuccess(httpActionLogger::onRequestCreation)
         .flatMap(
-            request -> invokeEndpoint(request)
-                .doOnSuccess(
-                    response -> logResponse(request, HttpResponseData.from(response), actionLogger))
-                .doOnError(throwable -> logErrorAndRequest(actionLogger, throwable, request))
+            request -> endpointInvoker.invokeEndpoint(request)
+                .doOnSuccess(httpActionLogger::onRequestSucceeded)
+                .doOnError(httpActionLogger::onRequestFailed)
                 .map(EndpointResponse::fromHttpResponse)
-                .onErrorReturn(this::handleTimeout)
-                .map(response -> createFragmentResult(fragmentContext, request, response,
-                    actionLogger)));
+                .onErrorReturn(HttpAction::handleTimeout)
+                .map(response -> responseProcessor.handleResponse(request, response, httpActionLogger)))
+        .map(result -> composeFragmentResult(fragmentContext.getFragment(), result, httpActionLogger))
+        .doOnError(httpActionLogger::onDifferentError)
+        .onErrorReturn(error -> errorTransition(fragmentContext, httpActionLogger));
   }
 
-  private Single<HttpResponse<Buffer>> invokeEndpoint(EndpointRequest request) {
-    return Single.just(request)
-        .map(this::createHttpRequest)
-        .doOnSuccess(this::addPredicates)
-        .flatMap(HttpRequest::rxSend);
+  private FragmentResult composeFragmentResult(Fragment fragment, HttpActionResult result, HttpActionLogger httpActionLogger) {
+    fragment.appendPayload(actionAlias, result.getActionPayload().toJson());
+    return new FragmentResult(fragment, result.getTransition(), httpActionLogger.getJsonNodeLog());
   }
 
-  private void addPredicates(HttpRequest<Buffer> request) {
-    if (isJsonPredicate) {
-      request.expect(io.vertx.reactivex.ext.web.client.predicate.ResponsePredicate
-          .newInstance(IS_JSON_RESPONSE));
-    }
-    attachResponsePredicatesToRequest(request,
-        httpActionOptions.getResponseOptions().getPredicates());
+  private static FragmentResult errorTransition(FragmentContext fragmentContext,
+      HttpActionLogger actionLogger) {
+    return new FragmentResult(fragmentContext.getFragment(), FragmentResult.ERROR_TRANSITION,
+        actionLogger.getJsonNodeLog());
   }
 
-  private void logRequest(ActionLogger actionLogger, EndpointRequest request) {
-    JsonObject headers = getHeadersFromRequest(request);
-    actionLogger.info(REQUEST, new JsonObject().put("path", request.getPath())
-        .put("requestHeaders", headers));
-  }
-
-  private void logErrorAndRequest(ActionLogger actionLogger, Throwable throwable,
-      EndpointRequest request) {
-    JsonObject headers = getHeadersFromRequest(request);
-    actionLogger.error(REQUEST, new JsonObject().put("path", request.getPath())
-        .put("requestHeaders", headers));
-    actionLogger.error(throwable);
-  }
-
-  private JsonObject getHeadersFromRequest(EndpointRequest request) {
-    JsonObject headers = new JsonObject();
-    request.getHeaders().entries().forEach(e -> headers.put(e.getKey(), e.getValue()));
-    return headers;
-  }
-
-  private void logResponseOnError(ActionLogger actionLogger, EndpointRequest request,
-      HttpResponseData httpResponseData) {
-    JsonObject responseData = getResponseData(request, httpResponseData);
-    actionLogger.error(RESPONSE, responseData);
-  }
-
-  private EndpointResponse handleTimeout(Throwable throwable) {
+  private static EndpointResponse handleTimeout(Throwable throwable) {
     if (throwable instanceof TimeoutException) {
       LOGGER.error("Error timeout: ", throwable);
       return new EndpointResponse(HttpResponseStatus.REQUEST_TIMEOUT);
@@ -186,204 +108,22 @@ public class HttpAction implements Action {
     throw Exceptions.propagate(throwable);
   }
 
-  private HttpRequest<Buffer> createHttpRequest(EndpointRequest endpointRequest) {
-    HttpRequest<Buffer> request = webClient
-        .request(HttpMethod.GET, endpointOptions.getPort(), endpointOptions.getDomain(),
-            endpointRequest.getPath())
-        .timeout(httpActionOptions.getRequestTimeoutMs());
-    endpointRequest.getHeaders().entries()
-        .forEach(entry -> request.putHeader(entry.getKey(), entry.getValue()));
-    return request;
-  }
+  public static class HttpActionResult {
+    private ActionPayload actionPayload;
+    private String transition;
 
-  private void attachResponsePredicatesToRequest(HttpRequest<Buffer> request,
-      Set<String> predicates) {
-    predicates.stream()
-        .filter(p -> !JSON.equals(p))
-        .forEach(p -> request.expect(predicatesProvider.fromName(p)));
-  }
-
-  private EndpointRequest createEndpointRequest(FragmentContext context) {
-    ClientRequest clientRequest = context.getClientRequest();
-    SourceDefinitions sourceDefinitions = buildSourceDefinitions(context, clientRequest);
-    String path = PlaceholdersResolver.resolve(endpointOptions.getPath(), sourceDefinitions);
-    MultiMap requestHeaders = getRequestHeaders(clientRequest);
-    return new EndpointRequest(path, requestHeaders);
-  }
-
-  private SourceDefinitions buildSourceDefinitions(FragmentContext context,
-      ClientRequest clientRequest) {
-    return SourceDefinitions.builder()
-        .addClientRequestSource(clientRequest)
-        .addJsonObjectSource(context.getFragment()
-            .getPayload(), PLACEHOLDER_PREFIX_PAYLOAD)
-        .addJsonObjectSource(context.getFragment()
-            .getConfiguration(), PLACEHOLDER_PREFIX_CONFIG)
-        .build();
-  }
-
-  private void logResponse(EndpointRequest endpointRequest, HttpResponseData resp,
-      ActionLogger actionLogger) {
-    JsonObject responseData = getResponseData(endpointRequest, resp);
-    if (isHttpErrorResponse(resp)) {
-      LOGGER.error("GET {} -> Error response {}, headers[{}]",
-          logResponseData(endpointRequest, resp));
-    } else if (LOGGER.isTraceEnabled()) {
-      LOGGER.trace("GET {} -> Got response {}, headers[{}]",
-          logResponseData(endpointRequest, resp));
+    public HttpActionResult(ActionPayload actionPayload, String transition) {
+      this.actionPayload = actionPayload;
+      this.transition = transition;
     }
-    actionLogger.info(RESPONSE, responseData);
-  }
 
-  private Object[] logResponseData(EndpointRequest request, HttpResponseData responseData) {
-    JsonObject headers = new JsonObject();
-    responseData.getHeaders().entries().forEach(e -> headers.put(e.getKey(), e.getValue()));
-    return new Object[]{
-        toUrl(request),
-        responseData.getStatusCode(),
-        headers
-    };
-  }
-
-  private boolean isHttpErrorResponse(HttpResponseData resp) {
-    return CLIENT_ERROR.contains(Integer.parseInt(resp.getStatusCode())) || SERVER_ERROR
-        .contains(Integer.parseInt(resp.getStatusCode()));
-  }
-
-  private JsonObject getResponseData(EndpointRequest request, HttpResponseData responseData) {
-    JsonObject json = responseData.toJson();
-    return json.put("httpMethod", HttpMethod.GET)
-        .put("requestPath", toUrl(request));
-  }
-
-  private String toUrl(EndpointRequest request) {
-    return endpointOptions.getDomain() + ":" + endpointOptions.getPort() + request.getPath();
-  }
-
-  private MultiMap getRequestHeaders(ClientRequest clientRequest) {
-    MultiMap filteredHeaders = getFilteredHeaders(clientRequest.getHeaders(),
-        endpointOptions.getAllowedRequestHeadersPatterns());
-    if (endpointOptions.getAdditionalHeaders() != null) {
-      endpointOptions.getAdditionalHeaders()
-          .forEach(entry -> filteredHeaders.add(entry.getKey(), entry.getValue().toString()));
+    ActionPayload getActionPayload() {
+      return actionPayload;
     }
-    return filteredHeaders;
-  }
 
-  private MultiMap getFilteredHeaders(MultiMap headers, List<Pattern> allowedHeaders) {
-    return headers.names().stream()
-        .filter(AllowedHeadersFilter.create(allowedHeaders))
-        .collect(MultiMapCollector.toMultiMap(o -> o, headers::getAll));
-  }
-
-  private FragmentResult createFragmentResult(FragmentContext fragmentContext,
-      EndpointRequest endpointRequest, EndpointResponse endpointResponse,
-      ActionLogger actionLogger) {
-    ActionRequest request = createActionRequest(endpointRequest);
-    final ActionPayload payload;
-    final String transition;
-    if (SUCCESS.contains(endpointResponse.getStatusCode().code())) {
-      actionLogger.info(RESPONSE_BODY, endpointResponse.getBody().toString());
-      payload = getActionPayload(endpointRequest, endpointResponse, actionLogger,
-          request);
-      transition = FragmentResult.SUCCESS_TRANSITION;
-    } else {
-      payload = handleErrorResponse(request, endpointResponse.getStatusCode().toString(),
-          endpointResponse.getStatusMessage());
-      transition = getErrorTransition(endpointResponse);
-      logErrorAndRequest(actionLogger, new IOException(
-          "The service responded with unsuccessful status code: " + endpointResponse.getStatusCode()
-              .code()), endpointRequest);
-      logResponseOnError(actionLogger, endpointRequest, HttpResponseData.from(endpointResponse));
-    }
-    updateResponseMetadata(endpointResponse, payload);
-    Fragment fragment = fragmentContext.getFragment();
-    fragment.appendPayload(actionAlias, payload.toJson());
-    return new FragmentResult(fragment, transition, actionLogger.toLog().toJson());
-  }
-
-  private String getErrorTransition(EndpointResponse endpointResponse) {
-    String transition;
-    if (isTimeout(endpointResponse)) {
-      transition = TIMEOUT_TRANSITION;
-    } else {
-      transition = ERROR_TRANSITION;
-    }
-    return transition;
-  }
-
-  private ActionPayload getActionPayload(EndpointRequest endpointRequest,
-      EndpointResponse endpointResponse, ActionLogger actionLogger, ActionRequest request) {
-    ActionPayload payload;
-    try {
-      payload = handleSuccessResponse(endpointResponse, request);
-    } catch (Exception e) {
-      logErrorAndRequest(actionLogger, e, endpointRequest);
-      logResponseOnError(actionLogger, endpointRequest,
-          HttpResponseData.from(endpointResponse));
-      throw e;
-    }
-    return payload;
-  }
-
-  private ActionRequest createActionRequest(EndpointRequest endpointRequest) {
-    ActionRequest request = new ActionRequest(HTTP_ACTION_TYPE, endpointRequest.getPath());
-    request.appendMetadata(METADATA_HEADERS_KEY, headersToJsonObject(endpointRequest.getHeaders()));
-    return request;
-  }
-
-  private void updateResponseMetadata(EndpointResponse response, ActionPayload payload) {
-    payload.getResponse()
-        .appendMetadata(METADATA_STATUS_CODE_KEY, String.valueOf(response.getStatusCode().code()))
-        .appendMetadata(METADATA_HEADERS_KEY, headersToJsonObject(response.getHeaders()));
-  }
-
-  private ActionPayload handleErrorResponse(ActionRequest request, String statusCode,
-      String statusMessage) {
-    return ActionPayload.error(request, statusCode, statusMessage);
-  }
-
-  private ActionPayload handleSuccessResponse(EndpointResponse response, ActionRequest request) {
-    if (isForceJson || isJsonPredicate || isContentTypeHeaderJson(response)) {
-      return ActionPayload.success(request, bodyToJson(response.getBody().toString()));
-    } else {
-      return ActionPayload.success(request, response.getBody().toString());
+    String getTransition() {
+      return transition;
     }
   }
 
-  private boolean isContentTypeHeaderJson(EndpointResponse endpointResponse) {
-    String contentType = endpointResponse.getHeaders().get(CONTENT_TYPE);
-    return contentType != null && contentType.contains(APPLICATION_JSON);
-  }
-
-  private Object bodyToJson(String responseBody) {
-    Object responseData;
-    if (StringUtils.isBlank(responseBody)) {
-      responseData = new JsonObject();
-    } else if (responseBody.startsWith("[")) {
-      responseData = new JsonArray(responseBody);
-    } else {
-      responseData = new JsonObject(responseBody);
-    }
-    return responseData;
-  }
-
-  private boolean isTimeout(EndpointResponse response) {
-    return HttpResponseStatus.REQUEST_TIMEOUT == response.getStatusCode();
-  }
-
-  private JsonObject headersToJsonObject(MultiMap headers) {
-    JsonObject responseHeaders = new JsonObject();
-    headers.entries().forEach(entry -> {
-      final JsonArray values;
-      if (responseHeaders.containsKey(entry.getKey())) {
-        values = responseHeaders.getJsonArray(entry.getKey());
-      } else {
-        values = new JsonArray();
-      }
-      responseHeaders.put(entry.getKey(), values.add(entry.getValue())
-      );
-    });
-    return responseHeaders;
-  }
 }

--- a/handler/actions/src/main/java/io/knotx/fragments/handler/action/http/WebClientCache.java
+++ b/handler/actions/src/main/java/io/knotx/fragments/handler/action/http/WebClientCache.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2019 Knot.x Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.knotx.fragments.handler.action.http;
+
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.client.WebClientOptions;
+import io.vertx.reactivex.ext.web.client.WebClient;
+
+class WebClientCache {
+
+  private static final long WEB_CLIENT_CACHE_SIZE = 200;
+
+  // Cache for WebClient, based on the configuration! (Can be shared between actions)
+  private Cache<JsonObject, WebClient> cache = CacheBuilder.newBuilder()
+      .maximumSize(WEB_CLIENT_CACHE_SIZE)
+      .build();
+
+  public WebClient getOrCreate(Vertx vertx, WebClientOptions webClientOptions) {
+    WebClient webClient = cache.getIfPresent(webClientOptions.toJson());
+    if (webClient == null) {
+      return createAndCache(vertx, webClientOptions);
+    } else {
+      return webClient;
+    }
+  }
+
+  private WebClient createAndCache(Vertx vertx, WebClientOptions webClientOptions) {
+    WebClient webClient = WebClient
+        .create(io.vertx.reactivex.core.Vertx.newInstance(vertx), webClientOptions);
+    cache.put(webClientOptions.toJson(), webClient);
+    return webClient;
+  }
+
+}

--- a/handler/actions/src/main/java/io/knotx/fragments/handler/action/http/log/HttpActionLogbackLogger.java
+++ b/handler/actions/src/main/java/io/knotx/fragments/handler/action/http/log/HttpActionLogbackLogger.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2019 Knot.x Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.knotx.fragments.handler.action.http.log;
+
+import static io.netty.handler.codec.http.HttpStatusClass.CLIENT_ERROR;
+import static io.netty.handler.codec.http.HttpStatusClass.SERVER_ERROR;
+
+import io.knotx.commons.json.MultiMapTransformer;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+
+final class HttpActionLogbackLogger {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(HttpActionLogbackLogger.class);
+
+  private HttpActionLogbackLogger() {
+    // utility
+  }
+
+  static void logResponseOnLogbackLogger(HttpResponseData httpResponseData,
+      String httpMethod, String requestPath) {
+    if (isHttpErrorResponse(httpResponseData)) {
+      LOGGER.error("{} {} -> Error response {}, headers[{}]",
+          getVertxLogResponseParameters(httpResponseData, httpMethod, requestPath));
+    } else if (LOGGER.isTraceEnabled()) {
+      LOGGER.trace("{} {} -> Got response {}, headers[{}]",
+          getVertxLogResponseParameters(httpResponseData, httpMethod, requestPath));
+    }
+  }
+
+  private static boolean isHttpErrorResponse(HttpResponseData httpResponseData) {
+    return CLIENT_ERROR.contains(Integer.parseInt(httpResponseData.getStatusCode())) || SERVER_ERROR
+        .contains(Integer.parseInt(httpResponseData.getStatusCode()));
+  }
+
+  private static Object[] getVertxLogResponseParameters(HttpResponseData httpResponseData,
+      String httpMethod, String requestPath) {
+    return new Object[]{
+        httpMethod,
+        requestPath,
+        httpResponseData.getStatusCode(),
+        MultiMapTransformer.toJson(httpResponseData.getHeaders())
+    };
+  }
+}

--- a/handler/actions/src/main/java/io/knotx/fragments/handler/action/http/log/HttpActionLogger.java
+++ b/handler/actions/src/main/java/io/knotx/fragments/handler/action/http/log/HttpActionLogger.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright (C) 2019 Knot.x Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.knotx.fragments.handler.action.http.log;
+
+import io.knotx.commons.json.MultiMapTransformer;
+import io.knotx.fragments.handler.action.http.options.EndpointOptions;
+import io.knotx.fragments.handler.action.http.request.EndpointRequest;
+import io.knotx.fragments.handler.api.actionlog.ActionLogLevel;
+import io.vertx.core.json.JsonObject;
+import io.vertx.reactivex.core.buffer.Buffer;
+import io.vertx.reactivex.ext.web.client.HttpResponse;
+import org.apache.commons.lang3.StringUtils;
+
+public class HttpActionLogger {
+
+  private HttpActionNodeLogger httpActionNodeLogger;
+  private EndpointOptions endpointOptions;
+  private String httpMethod;
+
+  private EndpointRequest endpointRequest;
+  private HttpResponseData httpResponseData;
+  private Buffer httpResponseBody;
+
+  private HttpActionLogger(HttpActionNodeLogger httpActionNodeLogger,
+      EndpointOptions endpointOptions, String httpMethod) {
+    this.httpActionNodeLogger = httpActionNodeLogger;
+    this.endpointOptions = endpointOptions;
+    this.httpMethod = httpMethod;
+  }
+
+  public static HttpActionLogger create(String actionAlias, ActionLogLevel logLevel,
+      EndpointOptions endpointOptions, String httpMethod) {
+    return new HttpActionLogger(HttpActionNodeLogger.create(actionAlias, logLevel),
+        endpointOptions, httpMethod);
+  }
+
+  public JsonObject getJsonNodeLog() {
+    return httpActionNodeLogger.getJsonNodeLog();
+  }
+
+  public void onRequestCreation(EndpointRequest endpointRequest) {
+    this.endpointRequest = endpointRequest;
+    logRequest(ActionLogLevel.INFO);
+  }
+
+  public void onRequestSucceeded(HttpResponse<Buffer> response) {
+    this.httpResponseData = HttpResponseData.from(response);
+    this.httpResponseBody = response.body();
+    logResponse(ActionLogLevel.INFO);
+    logResponseOnLogbackLogger();
+  }
+
+  private void logResponseOnLogbackLogger() {
+    HttpActionLogbackLogger.logResponseOnLogbackLogger(httpResponseData, httpMethod, getRequestPath());
+  }
+
+  public void onRequestFailed(Throwable throwable) {
+    logRequest(ActionLogLevel.ERROR);
+    logError(throwable);
+  }
+
+  public void onResponseCodeUnsuccessful(Throwable throwable) {
+    logRequest(ActionLogLevel.ERROR);
+    if (httpResponseData != null) {
+      logResponse(ActionLogLevel.ERROR);
+    }
+    logError(throwable);
+  }
+
+  public void onResponseProcessingFailed(Throwable throwable) {
+    logRequest(ActionLogLevel.ERROR);
+    logResponse(ActionLogLevel.ERROR);
+    logError(throwable);
+  }
+
+  public void onResponseCodeSuccessful() {
+    logResponseBody();
+  }
+
+  private void logResponseBody() {
+    httpActionNodeLogger.logResponseBody(httpResponseBody != null ? httpResponseBody.toString() : StringUtils.EMPTY);
+  }
+
+  public void onDifferentError(Throwable throwable) {
+    if (endpointRequest != null) {
+      logRequest(ActionLogLevel.ERROR);
+    }
+    if (httpResponseData != null) {
+      logResponse(ActionLogLevel.ERROR);
+    }
+    logError(throwable);
+  }
+
+  private void logRequest(ActionLogLevel logLevel) {
+    httpActionNodeLogger.logRequest(logLevel, getRequestData());
+  }
+
+  private void logResponse(ActionLogLevel logLevel) {
+    httpActionNodeLogger.logResponse(logLevel, getResponseData());
+  }
+
+  private void logError(Throwable throwable) {
+    httpActionNodeLogger.logError(throwable);
+  }
+
+  private JsonObject getRequestData() {
+    return new JsonObject().put("path", endpointRequest.getPath())
+        .put("requestHeaders", MultiMapTransformer.toJson(endpointRequest.getHeaders()));
+  }
+
+  private JsonObject getResponseData() {
+    return httpResponseData.toJson().put("httpMethod", httpMethod)
+        .put("requestPath", getRequestPath());
+  }
+
+  private String getRequestPath() {
+    return endpointOptions.getDomain() + ":" + endpointOptions.getPort() + endpointRequest
+        .getPath();
+  }
+
+}

--- a/handler/actions/src/main/java/io/knotx/fragments/handler/action/http/log/HttpActionNodeLogger.java
+++ b/handler/actions/src/main/java/io/knotx/fragments/handler/action/http/log/HttpActionNodeLogger.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2019 Knot.x Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.knotx.fragments.handler.action.http.log;
+
+import io.knotx.fragments.handler.api.actionlog.ActionLogLevel;
+import io.knotx.fragments.handler.api.actionlog.ActionLogger;
+import io.vertx.core.json.JsonObject;
+
+class HttpActionNodeLogger {
+
+  private static final String REQUEST = "request";
+  private static final String RESPONSE = "response";
+  private static final String RESPONSE_BODY = "responseBody";
+
+  private ActionLogger actionLogger;
+
+  private HttpActionNodeLogger(ActionLogger actionLogger) {
+    this.actionLogger = actionLogger;
+  }
+
+  static HttpActionNodeLogger create(String alias, ActionLogLevel actionLogLevel) {
+    return new HttpActionNodeLogger(ActionLogger.create(alias, actionLogLevel));
+  }
+
+  JsonObject getJsonNodeLog() {
+    return actionLogger.toLog().toJson();
+  }
+
+  void logRequest(ActionLogLevel level, JsonObject requestData) {
+    log(level, REQUEST, requestData);
+  }
+
+  void logResponse(ActionLogLevel level, JsonObject responseData) {
+    log(level, RESPONSE, responseData);
+  }
+
+  void logResponseBody(String responseBody) {
+    actionLogger.info(RESPONSE_BODY, responseBody);
+  }
+
+  void logError(Throwable throwable) {
+    actionLogger.error(throwable);
+  }
+
+  private void log(ActionLogLevel logLevel, String key, JsonObject value) {
+    if(ActionLogLevel.INFO.equals(logLevel)) {
+      actionLogger.info(key, value);
+    } else {
+      actionLogger.error(key, value);
+    }
+  }
+
+}

--- a/handler/actions/src/main/java/io/knotx/fragments/handler/action/http/log/HttpResponseData.java
+++ b/handler/actions/src/main/java/io/knotx/fragments/handler/action/http/log/HttpResponseData.java
@@ -13,16 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.knotx.fragments.handler.action.http;
+package io.knotx.fragments.handler.action.http.log;
 
+import io.knotx.commons.json.MultiMapTransformer;
 import io.vertx.core.json.JsonObject;
 import io.vertx.reactivex.core.MultiMap;
 import io.vertx.reactivex.core.buffer.Buffer;
 import io.vertx.reactivex.ext.web.client.HttpResponse;
-import java.util.List;
-import java.util.Map.Entry;
 
-public class HttpResponseData {
+class HttpResponseData {
 
   private static final String HTTP_VERSION_KEY = "httpVersion";
   private static final String STATUS_CODE_KEY = "statusCode";
@@ -45,7 +44,7 @@ public class HttpResponseData {
     this.trailers = trailers;
   }
 
-  public static HttpResponseData from(HttpResponse<Buffer> response) {
+  static HttpResponseData from(HttpResponse<Buffer> response) {
     return new HttpResponseData(
         String.valueOf(response.version()),
         String.valueOf(response.statusCode()),
@@ -55,49 +54,21 @@ public class HttpResponseData {
     );
   }
 
-  public static HttpResponseData from(EndpointResponse endpointResponse) {
-    return new HttpResponseData(
-        String.valueOf(endpointResponse.getHttpVersion()),
-        String.valueOf(endpointResponse.getStatusCode()),
-        endpointResponse.getStatusMessage(),
-        endpointResponse.getHeaders(),
-        endpointResponse.getTrailers()
-    );
-  }
-
-  public JsonObject toJson() {
+  JsonObject toJson() {
     return new JsonObject()
         .put(HTTP_VERSION_KEY, httpVersion)
         .put(STATUS_CODE_KEY, statusCode)
         .put(STATUS_MESSAGE_KEY, statusMessage)
-        .put(HEADERS_KEY, multiMapToJson(headers.entries()))
-        .put(TRAILERS_KEY, multiMapToJson(trailers.entries()));
+        .put(HEADERS_KEY, MultiMapTransformer.toJson(headers))
+        .put(TRAILERS_KEY, MultiMapTransformer.toJson(trailers));
   }
 
-  public String getHttpVersion() {
-    return httpVersion;
-  }
-
-  public String getStatusCode() {
+  String getStatusCode() {
     return statusCode;
   }
 
-  public String getStatusMessage() {
-    return statusMessage;
-  }
-
-  public MultiMap getHeaders() {
+  MultiMap getHeaders() {
     return headers;
-  }
-
-  public MultiMap getTrailers() {
-    return trailers;
-  }
-
-  private static JsonObject multiMapToJson(List<Entry<String, String>> entries) {
-    JsonObject json = new JsonObject();
-    entries.forEach(e -> json.put(e.getKey(), e.getValue()));
-    return json;
   }
 
   @Override

--- a/handler/actions/src/main/java/io/knotx/fragments/handler/action/http/options/EndpointOptions.java
+++ b/handler/actions/src/main/java/io/knotx/fragments/handler/action/http/options/EndpointOptions.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.knotx.fragments.handler.action.http;
+package io.knotx.fragments.handler.action.http.options;
 
 import io.vertx.codegen.annotations.DataObject;
 import io.vertx.codegen.annotations.GenIgnore;
@@ -57,7 +57,7 @@ public class EndpointOptions {
     EndpointOptionsConverter.fromJson(json, this);
     if (allowedRequestHeaders != null) {
       allowedRequestHeadersPatterns = allowedRequestHeaders.stream()
-          .map(expr -> Pattern.compile(expr)).collect(Collectors.toList());
+          .map(Pattern::compile).collect(Collectors.toList());
     }
   }
 

--- a/handler/actions/src/main/java/io/knotx/fragments/handler/action/http/options/HttpActionOptions.java
+++ b/handler/actions/src/main/java/io/knotx/fragments/handler/action/http/options/HttpActionOptions.java
@@ -13,8 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.knotx.fragments.handler.action.http;
+package io.knotx.fragments.handler.action.http.options;
 
+import io.netty.handler.codec.http.HttpMethod;
 import io.vertx.codegen.annotations.DataObject;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.client.WebClientOptions;
@@ -27,6 +28,7 @@ public class HttpActionOptions {
 
   private static final long DEFAULT_REQUEST_TIMEOUT = 0L;
 
+  private String httpMethod = HttpMethod.GET.name();
   private WebClientOptions webClientOptions = new WebClientOptions();
   private EndpointOptions endpointOptions = new EndpointOptions();
   private ResponseOptions responseOptions = new ResponseOptions();
@@ -38,6 +40,22 @@ public class HttpActionOptions {
 
   public HttpActionOptions(JsonObject json) {
     HttpActionOptionsConverter.fromJson(json, this);
+  }
+
+  public String getHttpMethod() {
+    return httpMethod;
+  }
+
+  /**
+   * Set the {@code HttpMethod} used for performing the request.
+   * At the moment only HTTP GET method is supported.
+   *
+   * @param httpMethod HTTP method
+   * @return a reference to this, so the API can be used fluently
+   */
+  HttpActionOptions setHttpMethod(String httpMethod) {
+    this.httpMethod = httpMethod;
+    return this;
   }
 
   public WebClientOptions getWebClientOptions() {
@@ -52,7 +70,7 @@ public class HttpActionOptions {
    * @param webClientOptions {@link WebClientOptions} object
    * @return a reference to this, so the API can be used fluently
    */
-  public HttpActionOptions setWebClientOptions(WebClientOptions webClientOptions) {
+  HttpActionOptions setWebClientOptions(WebClientOptions webClientOptions) {
     this.webClientOptions = webClientOptions;
     return this;
   }

--- a/handler/actions/src/main/java/io/knotx/fragments/handler/action/http/options/ResponseOptions.java
+++ b/handler/actions/src/main/java/io/knotx/fragments/handler/action/http/options/ResponseOptions.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.knotx.fragments.handler.action.http;
+package io.knotx.fragments.handler.action.http.options;
 
 import io.vertx.codegen.annotations.DataObject;
 import io.vertx.core.json.JsonObject;

--- a/handler/actions/src/main/java/io/knotx/fragments/handler/action/http/request/EndpointRequest.java
+++ b/handler/actions/src/main/java/io/knotx/fragments/handler/action/http/request/EndpointRequest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2019 Knot.x Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.knotx.fragments.handler.action.http.request;
+
+import io.vertx.reactivex.core.MultiMap;
+
+public class EndpointRequest {
+
+  private final String path;
+  private final MultiMap headers;
+
+  public EndpointRequest(String path, MultiMap headers) {
+    this.path = path;
+    this.headers = headers;
+  }
+
+  public String getPath() {
+    return path;
+  }
+
+  public MultiMap getHeaders() {
+    return headers;
+  }
+
+}

--- a/handler/actions/src/main/java/io/knotx/fragments/handler/action/http/request/EndpointRequestComposer.java
+++ b/handler/actions/src/main/java/io/knotx/fragments/handler/action/http/request/EndpointRequestComposer.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2019 Knot.x Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.knotx.fragments.handler.action.http.request;
+
+import io.knotx.commons.http.request.AllowedHeadersFilter;
+import io.knotx.commons.http.request.MultiMapCollector;
+import io.knotx.fragments.handler.action.http.options.EndpointOptions;
+import io.knotx.fragments.handler.api.domain.FragmentContext;
+import io.knotx.server.api.context.ClientRequest;
+import io.knotx.server.common.placeholders.PlaceholdersResolver;
+import io.knotx.server.common.placeholders.SourceDefinitions;
+import io.vertx.reactivex.core.MultiMap;
+import java.util.List;
+import java.util.regex.Pattern;
+
+public class EndpointRequestComposer {
+
+  private static final String PLACEHOLDER_PREFIX_PAYLOAD = "payload";
+  private static final String PLACEHOLDER_PREFIX_CONFIG = "config";
+
+  private EndpointOptions endpointOptions;
+
+  public EndpointRequestComposer(EndpointOptions endpointOptions) {
+    this.endpointOptions = endpointOptions;
+  }
+
+  public EndpointRequest createEndpointRequest(FragmentContext context) {
+    ClientRequest clientRequest = context.getClientRequest();
+    SourceDefinitions sourceDefinitions = buildSourceDefinitions(context, clientRequest);
+    String path = PlaceholdersResolver.resolve(endpointOptions.getPath(), sourceDefinitions);
+    MultiMap requestHeaders = getRequestHeaders(clientRequest);
+    return new EndpointRequest(path, requestHeaders);
+  }
+
+  private SourceDefinitions buildSourceDefinitions(FragmentContext context,
+      ClientRequest clientRequest) {
+    return SourceDefinitions.builder()
+        .addClientRequestSource(clientRequest)
+        .addJsonObjectSource(context.getFragment()
+            .getPayload(), PLACEHOLDER_PREFIX_PAYLOAD)
+        .addJsonObjectSource(context.getFragment()
+            .getConfiguration(), PLACEHOLDER_PREFIX_CONFIG)
+        .build();
+  }
+
+  private MultiMap getRequestHeaders(ClientRequest clientRequest) {
+    MultiMap filteredHeaders = getFilteredHeaders(clientRequest.getHeaders(),
+        endpointOptions.getAllowedRequestHeadersPatterns());
+    if (endpointOptions.getAdditionalHeaders() != null) {
+      endpointOptions.getAdditionalHeaders()
+          .forEach(entry -> filteredHeaders.add(entry.getKey(), entry.getValue().toString()));
+    }
+    return filteredHeaders;
+  }
+
+  private MultiMap getFilteredHeaders(MultiMap headers, List<Pattern> allowedHeaders) {
+    return headers.names().stream()
+        .filter(AllowedHeadersFilter.create(allowedHeaders))
+        .collect(MultiMapCollector.toMultiMap(o -> o, headers::getAll));
+  }
+
+}

--- a/handler/actions/src/main/java/io/knotx/fragments/handler/action/http/request/ResponsePredicatesProvider.java
+++ b/handler/actions/src/main/java/io/knotx/fragments/handler/action/http/request/ResponsePredicatesProvider.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.knotx.fragments.handler.action.http;
+package io.knotx.fragments.handler.action.http.request;
 
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;

--- a/handler/actions/src/main/java/io/knotx/fragments/handler/action/http/response/EndpointResponse.java
+++ b/handler/actions/src/main/java/io/knotx/fragments/handler/action/http/response/EndpointResponse.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.knotx.fragments.handler.action.http;
+package io.knotx.fragments.handler.action.http.response;
 
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.vertx.core.http.HttpVersion;
@@ -21,7 +21,7 @@ import io.vertx.reactivex.core.MultiMap;
 import io.vertx.reactivex.core.buffer.Buffer;
 import io.vertx.reactivex.ext.web.client.HttpResponse;
 
-class EndpointResponse {
+public class EndpointResponse {
 
   private final HttpResponseStatus statusCode;
   private String statusMessage;
@@ -30,11 +30,11 @@ class EndpointResponse {
   private MultiMap trailers = MultiMap.caseInsensitiveMultiMap();
   private Buffer body;
 
-  EndpointResponse(HttpResponseStatus statusCode) {
+  public EndpointResponse(HttpResponseStatus statusCode) {
     this.statusCode = statusCode;
   }
 
-  static EndpointResponse fromHttpResponse(HttpResponse<Buffer> response) {
+  public static EndpointResponse fromHttpResponse(HttpResponse<Buffer> response) {
     EndpointResponse endpointResponse = new EndpointResponse(
         HttpResponseStatus.valueOf(response.statusCode()));
     endpointResponse.body = getResponseBody(response);
@@ -46,7 +46,7 @@ class EndpointResponse {
   }
 
 
-  public HttpResponseStatus getStatusCode() {
+  HttpResponseStatus getStatusCode() {
     return statusCode;
   }
 
@@ -62,7 +62,7 @@ class EndpointResponse {
     return body;
   }
 
-  public String getStatusMessage() {
+  String getStatusMessage() {
     return statusMessage;
   }
 

--- a/handler/actions/src/main/java/io/knotx/fragments/handler/action/http/response/EndpointResponseProcessor.java
+++ b/handler/actions/src/main/java/io/knotx/fragments/handler/action/http/response/EndpointResponseProcessor.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright (C) 2019 Knot.x Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.knotx.fragments.handler.action.http.response;
+
+import static io.knotx.fragments.handler.api.domain.FragmentResult.ERROR_TRANSITION;
+
+import io.knotx.commons.json.MultiMapTransformer;
+import io.knotx.fragments.handler.action.http.HttpAction.HttpActionResult;
+import io.knotx.fragments.handler.action.http.log.HttpActionLogger;
+import io.knotx.fragments.handler.action.http.options.ResponseOptions;
+import io.knotx.fragments.handler.action.http.request.EndpointRequest;
+import io.knotx.fragments.handler.api.domain.FragmentResult;
+import io.knotx.fragments.handler.api.domain.payload.ActionPayload;
+import io.knotx.fragments.handler.api.domain.payload.ActionRequest;
+import io.knotx.fragments.handler.api.domain.payload.ActionResponse;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpHeaderValues;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpStatusClass;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import java.io.IOException;
+import org.apache.commons.lang3.StringUtils;
+
+public class EndpointResponseProcessor {
+
+  public static final String TIMEOUT_TRANSITION = "_timeout";
+  private static final String HTTP_ACTION_TYPE = "HTTP";
+  private static final String METADATA_HEADERS_KEY = "headers";
+  private static final String METADATA_STATUS_CODE_KEY = "statusCode";
+  private static final String JSON = "JSON";
+  private final boolean isJsonPredicate;
+  private final boolean isForceJson;
+
+  public EndpointResponseProcessor(ResponseOptions responseOptions) {
+    this.isJsonPredicate = responseOptions.getPredicates().contains(JSON);
+    this.isForceJson = responseOptions.isForceJson();
+  }
+
+  public HttpActionResult handleResponse(EndpointRequest endpointRequest,
+      EndpointResponse endpointResponse, HttpActionLogger actionLogger) {
+    if (isConsideredSuccess(endpointResponse)) {
+      return handleWithSuccessResponseCode(endpointRequest, endpointResponse, actionLogger);
+    } else {
+      return handleWithErrorResponseCode(endpointRequest, endpointResponse, actionLogger);
+    }
+  }
+
+  private HttpActionResult handleWithSuccessResponseCode(EndpointRequest endpointRequest,
+      EndpointResponse endpointResponse, HttpActionLogger actionLogger) {
+    actionLogger.onResponseCodeSuccessful();
+    ActionPayload payload = successResponsePayload(endpointRequest, endpointResponse, actionLogger);
+    return new HttpActionResult(payload, FragmentResult.SUCCESS_TRANSITION);
+  }
+
+  private HttpActionResult handleWithErrorResponseCode(EndpointRequest endpointRequest,
+      EndpointResponse endpointResponse, HttpActionLogger actionLogger) {
+    actionLogger.onResponseCodeUnsuccessful(new IOException(
+        "The service responded with unsuccessful status code: " + endpointResponse.getStatusCode()
+            .code()));
+    ActionPayload payload = errorResponsePayload(endpointRequest, endpointResponse);
+    return new HttpActionResult(payload, getErrorTransition(endpointResponse));
+  }
+
+  private ActionPayload successResponsePayload(EndpointRequest endpointRequest,
+      EndpointResponse endpointResponse, HttpActionLogger httpActionLogger) {
+    ActionRequest actionRequest = createActionRequest(endpointRequest);
+    ActionResponse actionResponse = createSuccessActionResponse(endpointResponse);
+    Object result = tryToRetrieveResultFrom(endpointResponse, httpActionLogger);
+    return ActionPayload.create(actionRequest, actionResponse, result);
+  }
+
+  private ActionPayload errorResponsePayload(EndpointRequest endpointRequest,
+      EndpointResponse endpointResponse) {
+    ActionRequest actionRequest = createActionRequest(endpointRequest);
+    ActionResponse actionResponse = createErrorActionResponse(endpointResponse);
+    return ActionPayload.noResult(actionRequest, actionResponse);
+  }
+
+  private ActionRequest createActionRequest(EndpointRequest endpointRequest) {
+    ActionRequest request = new ActionRequest(HTTP_ACTION_TYPE, endpointRequest.getPath());
+    request.appendMetadata(METADATA_HEADERS_KEY,
+        MultiMapTransformer.toJson(endpointRequest.getHeaders()));
+    return request;
+  }
+
+  private ActionResponse createSuccessActionResponse(EndpointResponse endpointResponse) {
+    return ActionResponse.success()
+        .appendMetadata(METADATA_STATUS_CODE_KEY,
+            String.valueOf(endpointResponse.getStatusCode().code()))
+        .appendMetadata(METADATA_HEADERS_KEY,
+            MultiMapTransformer.toJson(endpointResponse.getHeaders()));
+  }
+
+  private ActionResponse createErrorActionResponse(EndpointResponse endpointResponse) {
+    return ActionResponse
+        .error(endpointResponse.getStatusCode().toString(), endpointResponse.getStatusMessage())
+        .appendMetadata(METADATA_STATUS_CODE_KEY,
+            String.valueOf(endpointResponse.getStatusCode().code()))
+        .appendMetadata(METADATA_HEADERS_KEY,
+            MultiMapTransformer.toJson(endpointResponse.getHeaders()));
+  }
+
+  private Object tryToRetrieveResultFrom(EndpointResponse endpointResponse,
+      HttpActionLogger httpActionLogger) {
+    try {
+      return retrieveResultFrom(endpointResponse);
+    } catch (Exception exception) {
+      httpActionLogger.onResponseProcessingFailed(exception);
+      throw exception;
+    }
+  }
+
+  private Object retrieveResultFrom(EndpointResponse response) {
+    if (isForceJson || isJsonPredicate || isContentTypeHeaderJson(response)) {
+      return bodyToJson(response.getBody().toString());
+    } else {
+      return response.getBody().toString();
+    }
+  }
+
+  private boolean isContentTypeHeaderJson(EndpointResponse endpointResponse) {
+    String contentType = endpointResponse.getHeaders().get(HttpHeaderNames.CONTENT_TYPE);
+    return contentType != null && contentType.contains(HttpHeaderValues.APPLICATION_JSON);
+  }
+
+  private Object bodyToJson(String responseBody) {
+    if (StringUtils.isBlank(responseBody)) {
+      return new JsonObject();
+    } else if (responseBody.startsWith("[")) {
+      return new JsonArray(responseBody);
+    } else {
+      return new JsonObject(responseBody);
+    }
+  }
+
+  private String getErrorTransition(EndpointResponse endpointResponse) {
+    if (isTimeout(endpointResponse)) {
+      return TIMEOUT_TRANSITION;
+    } else {
+      return ERROR_TRANSITION;
+    }
+  }
+
+  private boolean isConsideredSuccess(EndpointResponse response) {
+    return !HttpStatusClass.CLIENT_ERROR.contains(response.getStatusCode().code())
+        && !HttpStatusClass.SERVER_ERROR.contains(response.getStatusCode().code());
+  }
+
+  private boolean isTimeout(EndpointResponse response) {
+    return HttpResponseStatus.REQUEST_TIMEOUT == response.getStatusCode();
+  }
+
+}

--- a/handler/actions/src/test/java/io/knotx/fragments/handler/action/http/HttpActionFactoryTest.java
+++ b/handler/actions/src/test/java/io/knotx/fragments/handler/action/http/HttpActionFactoryTest.java
@@ -18,25 +18,27 @@ package io.knotx.fragments.handler.action.http;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import io.knotx.fragments.handler.action.exception.ActionConfigurationException;
+import io.knotx.fragments.handler.api.Cacheable;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
 import io.vertx.junit5.VertxExtension;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(VertxExtension.class)
-public class HttpActionFactoryTest {
+class HttpActionFactoryTest {
 
   @Test
   @DisplayName("Expect exception when doAction provided")
-  void expectExceptionWhenDoActionProvided(Vertx vertx) throws Throwable {
+  void expectExceptionWhenDoActionProvided(Vertx vertx) {
     HttpActionFactory actionFactory = new HttpActionFactory();
     JsonObject config = new JsonObject();
-    assertThrows(IllegalArgumentException.class, () -> {
-      actionFactory.create("", config, vertx, (fragmentContext, resultHandler) -> {
-      });
-    });
+    assertThrows(ActionConfigurationException.class,
+        () -> actionFactory.create("", config, vertx, (fragmentContext, resultHandler) -> {})
+    );
   }
 
   @Test
@@ -45,5 +47,12 @@ public class HttpActionFactoryTest {
     HttpActionFactory actionFactory = new HttpActionFactory();
     JsonObject config = new JsonObject();
     assertTrue(actionFactory.create("", config, vertx, null) instanceof HttpAction);
+  }
+
+  @Test
+  @DisplayName("Http Action is stateless and should be cached.")
+  void shouldBeCacheable() {
+    Class<?> tested = HttpActionFactory.class;
+    Assertions.assertNotNull(tested.getAnnotation(Cacheable.class));
   }
 }

--- a/handler/actions/src/test/java/io/knotx/fragments/handler/action/http/HttpActionNodeLogTest.java
+++ b/handler/actions/src/test/java/io/knotx/fragments/handler/action/http/HttpActionNodeLogTest.java
@@ -25,6 +25,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
 import io.knotx.fragments.api.Fragment;
+import io.knotx.fragments.handler.action.http.options.EndpointOptions;
+import io.knotx.fragments.handler.action.http.options.HttpActionOptions;
+import io.knotx.fragments.handler.action.http.options.ResponseOptions;
 import io.knotx.fragments.handler.api.actionlog.ActionLogLevel;
 import io.knotx.fragments.handler.api.domain.FragmentContext;
 import io.knotx.fragments.handler.api.domain.FragmentResult;
@@ -33,9 +36,11 @@ import io.netty.util.internal.StringUtil;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.client.WebClientOptions;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import io.vertx.reactivex.core.MultiMap;
+import io.vertx.reactivex.ext.web.client.WebClient;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Optional;
@@ -59,7 +64,7 @@ import org.mockito.quality.Strictness;
 @ExtendWith(VertxExtension.class)
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.WARN)
-public class HttpActionNodeLogTest {
+class HttpActionNodeLogTest {
 
   private static final String ACTION_ALIAS = "httpAction";
   private static final String RAW_BODY = "<html>Hello</html>";
@@ -246,11 +251,12 @@ public class HttpActionNodeLogTest {
         .setPredicates(predicates)
         .setForceJson(forceJson);
 
-    return new HttpAction(vertx,
+    return new HttpAction(createDefaultWebClient(vertx),
         new HttpActionOptions()
             .setEndpointOptions(endpointOptions)
-            .setResponseOptions(responseOptions),
-        ACTION_ALIAS, logLevel);
+            .setResponseOptions(responseOptions)
+          .setLogLevel(logLevel.getLevel()),
+        ACTION_ALIAS);
   }
 
   private static void assertRequestLogs(JsonObject requestLog) {
@@ -303,4 +309,7 @@ public class HttpActionNodeLogTest {
     return new Fragment("type", EMPTY_JSON, "expectedBody");
   }
 
+  private WebClient createDefaultWebClient(Vertx vertx) {
+    return WebClient.create(io.vertx.reactivex.core.Vertx.newInstance(vertx), new WebClientOptions());
+  }
 }

--- a/handler/actions/src/test/java/io/knotx/fragments/handler/action/http/ResponsePredicatesProviderTest.java
+++ b/handler/actions/src/test/java/io/knotx/fragments/handler/action/http/ResponsePredicatesProviderTest.java
@@ -18,6 +18,7 @@ package io.knotx.fragments.handler.action.http;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import io.knotx.fragments.handler.action.http.request.ResponsePredicatesProvider;
 import io.vertx.reactivex.ext.web.client.predicate.ResponsePredicate;
 import java.util.stream.Stream;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -55,16 +56,13 @@ class ResponsePredicatesProviderTest {
 
   @ParameterizedTest(name = "Expect valid response predicate")
   @MethodSource("dataResponsePredicates")
-  void shouldReturnValidResponsePredicate(String name, ResponsePredicate expectedPredicate)
-      throws Throwable {
+  void shouldReturnValidResponsePredicate(String name, ResponsePredicate expectedPredicate) {
     assertEquals(expectedPredicate, predicatesProvider.fromName(name));
   }
 
   @ParameterizedTest(name = "Should throw exception when nonexisting predicate requested")
   @MethodSource("dataNonExistingPredicates")
   void shouldThrowExceptionWhenNonExistingPredicateRequested(String predicate) {
-    assertThrows(IllegalArgumentException.class, () -> {
-      predicatesProvider.fromName(predicate);
-    });
+    assertThrows(IllegalArgumentException.class, () -> predicatesProvider.fromName(predicate));
   }
 }

--- a/handler/actions/src/test/java/io/knotx/fragments/handler/action/http/WebClientCacheTest.java
+++ b/handler/actions/src/test/java/io/knotx/fragments/handler/action/http/WebClientCacheTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2019 Knot.x Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.knotx.fragments.handler.action.http;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.vertx.core.Vertx;
+import io.vertx.ext.web.client.WebClientOptions;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+import io.vertx.reactivex.ext.web.client.WebClient;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(VertxExtension.class)
+class WebClientCacheTest {
+
+  private WebClientCache webClientCache;
+
+  @BeforeEach
+  void setUp() {
+    webClientCache = new WebClientCache();
+  }
+
+  @Test
+  @DisplayName("Should provide different WebClient instance when configuration is different")
+  void testDifferentConfigurations(VertxTestContext testContext, Vertx vertx) {
+    WebClientOptions optionsA = new WebClientOptions().setSsl(true).setDefaultPort(80);
+    WebClientOptions optionsB = new WebClientOptions().setSsl(false).setDefaultPort(8080);
+
+    WebClient webClientA = webClientCache.getOrCreate(vertx, optionsA);
+    WebClient webClientB = webClientCache.getOrCreate(vertx, optionsB);
+
+    assertNotEquals(webClientA, webClientB);
+    testContext.completeNow();
+  }
+
+  @Test
+  @DisplayName("Should provide same WebClient instance when configuration is equivalent")
+  void testEqualConfigurations(VertxTestContext testContext, Vertx vertx) {
+    WebClientOptions optionsA = new WebClientOptions().setSsl(true).setDefaultPort(80);
+    WebClientOptions optionsB = new WebClientOptions().setSsl(true).setDefaultPort(80);
+
+    WebClient webClientA = webClientCache.getOrCreate(vertx, optionsA);
+    WebClient webClientB = webClientCache.getOrCreate(vertx, optionsB);
+
+    assertEquals(webClientA, webClientB);
+    testContext.completeNow();
+  }
+
+}

--- a/handler/actions/src/test/java/io/knotx/fragments/handler/action/http/log/HttpActionLoggerTest.java
+++ b/handler/actions/src/test/java/io/knotx/fragments/handler/action/http/log/HttpActionLoggerTest.java
@@ -1,0 +1,316 @@
+/*
+ * Copyright (C) 2019 Knot.x Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.knotx.fragments.handler.action.http.log;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+import io.knotx.fragments.handler.action.http.options.EndpointOptions;
+import io.knotx.fragments.handler.action.http.request.EndpointRequest;
+import io.knotx.fragments.handler.api.actionlog.ActionLogLevel;
+import io.netty.handler.codec.http.HttpMethod;
+import io.vertx.core.http.HttpVersion;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.reactivex.core.MultiMap;
+import io.vertx.reactivex.core.buffer.Buffer;
+import io.vertx.reactivex.ext.web.client.HttpResponse;
+import java.io.IOException;
+import java.util.concurrent.TimeoutException;
+import java.util.stream.Stream;
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class HttpActionLoggerTest {
+
+  private static final String SAMPLE_ACTION_ALIAS = "TestedAction";
+  private static final String REQUEST = "request";
+  private static final String RESPONSE = "response";
+  private static final String RESPONSE_BODY = "responseBody";
+  private static final String ERRORS = "errors";
+
+  private EndpointOptions endpointOptions;
+  private EndpointRequest endpointRequest;
+
+  @Mock
+  private HttpResponse<Buffer> httpResponse;
+
+  private HttpActionLogger tested;
+
+  private static Stream<Arguments> happyPathCases() {
+    return Stream.of( // logLevel, request, response, responseBody, error
+        Arguments.of(ActionLogLevel.INFO, true, true, true, false),
+        Arguments.of(ActionLogLevel.ERROR, false, false, false, false)
+    );
+  }
+
+  private static Stream<Arguments> requestFailureCases() {
+    return Stream.of( // logLevel, request, response, responseBody, error
+        Arguments.of(ActionLogLevel.INFO, true, false, false, true),
+        Arguments.of(ActionLogLevel.ERROR, true, false, false, true)
+    );
+  }
+
+  private static Stream<Arguments> responseCodeTimeoutCases() {
+    return Stream.of( // logLevel, request, response, responseBody, error
+        Arguments.of(ActionLogLevel.INFO, true, false, false, true),
+        Arguments.of(ActionLogLevel.ERROR, true, false, false, true)
+    );
+  }
+
+  private static Stream<Arguments> responseCodeUnsuccessfulCases() {
+    return Stream.of( // logLevel, request, response, responseBody, error
+        Arguments.of(ActionLogLevel.INFO, true, true, false, true),
+        Arguments.of(ActionLogLevel.ERROR, true, true, false, true)
+    );
+  }
+
+  private static Stream<Arguments> responseProcessingFailureCases() {
+    return Stream.of( // logLevel, request, response, responseBody, error
+        Arguments.of(ActionLogLevel.INFO, true, true, false, true),
+        Arguments.of(ActionLogLevel.ERROR, true, true, false, true)
+    );
+  }
+
+  private static Stream<Arguments> unexpectedErrorAfterProcessingCases() {
+    return Stream.of( // logLevel, request, response, responseBody, error
+        Arguments.of(ActionLogLevel.INFO, true, true, true, true),
+        Arguments.of(ActionLogLevel.ERROR, true, true, false, true)
+    );
+  }
+
+  @BeforeEach
+  void setUp() {
+    endpointOptions = new EndpointOptions()
+        .setDomain("http://api.service.com")
+        .setPort(8080);
+    endpointRequest = new EndpointRequest("/api/v1/data.json", MultiMap.caseInsensitiveMultiMap());
+  }
+
+  @ParameterizedTest
+  @MethodSource("happyPathCases")
+  @DisplayName("Expect log to contain desired information when request creation, response and responseBody are logged")
+  void testRequestSucceeded(ActionLogLevel level, boolean expectRequest, boolean expectResponse,
+      boolean expectResponseBody, boolean expectError) {
+    givenLogger(level);
+    givenResponse(HttpStatus.SC_OK);
+
+    whenRequestSucceeded();
+
+    thenLogContainsRequestData(expectRequest);
+    thenLogContainsResponse(expectResponse);
+    thenLogContainsResponseBody(expectResponseBody);
+    thenLogContainsError(expectError);
+  }
+
+  private void whenRequestSucceeded() {
+    tested.onRequestCreation(endpointRequest);
+    tested.onRequestSucceeded(httpResponse);
+    tested.onResponseCodeSuccessful();
+  }
+
+  @ParameterizedTest
+  @MethodSource("requestFailureCases")
+  @DisplayName("Expect log to contain desired information when request creation and request failure are logged")
+  void testRequestFailure(ActionLogLevel level, boolean expectRequest, boolean expectResponse,
+      boolean expectResponseBody, boolean expectError) {
+    givenLogger(level);
+
+    whenRequestFailed();
+
+    thenLogContainsRequestData(expectRequest);
+    thenLogContainsResponse(expectResponse);
+    thenLogContainsResponseBody(expectResponseBody);
+    thenLogContainsError(expectError);
+  }
+
+  @ParameterizedTest
+  @MethodSource("responseCodeTimeoutCases")
+  @DisplayName("Expect log to contain desired information when request creation, request failure and response unsuccessful code are logged")
+  void testResponseCodeTimeout(ActionLogLevel level, boolean expectRequest, boolean expectResponse,
+      boolean expectResponseBody, boolean expectError) {
+    givenLogger(level);
+
+    whenResponseCodeTimeout();
+
+    thenLogContainsRequestData(expectRequest);
+    thenLogContainsResponse(expectResponse);
+    thenLogContainsResponseBody(expectResponseBody);
+    thenLogContainsError(expectError);
+  }
+
+  @ParameterizedTest
+  @MethodSource("responseCodeUnsuccessfulCases")
+  @DisplayName("Expect log to contain desired information when request creation and response unsuccessful code are logged")
+  void testResponseCodeUnsuccessful(ActionLogLevel level, boolean expectRequest, boolean expectResponse,
+      boolean expectResponseBody, boolean expectError) {
+    givenLogger(level);
+    givenResponse(HttpStatus.SC_NOT_FOUND);
+
+    whenResponseCodeUnsuccessful();
+
+    thenLogContainsRequestData(expectRequest);
+    thenLogContainsResponse(expectResponse);
+    thenLogContainsResponseBody(expectResponseBody);
+    thenLogContainsError(expectError);
+  }
+
+  @ParameterizedTest
+  @MethodSource("responseProcessingFailureCases")
+  @DisplayName("Expect log to contain desired information when request creation, response and response processing failure are logged")
+  void testResponseProcessingFailure(ActionLogLevel level, boolean expectRequest, boolean expectResponse,
+      boolean expectResponseBody, boolean expectError) {
+    givenLogger(level);
+    givenResponse(HttpStatus.SC_OK);
+
+    whenResponseProcessingFailed();
+
+    thenLogContainsRequestData(expectRequest);
+    thenLogContainsResponse(expectResponse);
+    thenLogContainsResponseBody(expectResponseBody);
+    thenLogContainsError(expectError);
+  }
+
+  @ParameterizedTest
+  @MethodSource("unexpectedErrorAfterProcessingCases")
+  @DisplayName("Expect log to contain desired information when request creation, response, responseBody and unexpected error are logged")
+  void testUnexpectedErrorAfterResponseProcessing(ActionLogLevel level, boolean expectRequest, boolean expectResponse,
+      boolean expectResponseBody, boolean expectError) {
+    givenLogger(level);
+    givenResponse(HttpStatus.SC_OK);
+
+    whenUnexpectedErrorAfterResponseProcessing();
+
+    thenLogContainsRequestData(expectRequest);
+    thenLogContainsResponse(expectResponse);
+    thenLogContainsResponseBody(expectResponseBody);
+    thenLogContainsError(expectError);
+  }
+
+  private void givenLogger(ActionLogLevel level) {
+    tested = HttpActionLogger.create(SAMPLE_ACTION_ALIAS, level, endpointOptions, HttpMethod.GET.name());
+  }
+
+  private void givenResponse(int httpStatus) {
+    when(httpResponse.version()).thenReturn(HttpVersion.HTTP_2);
+    when(httpResponse.statusCode()).thenReturn(httpStatus);
+    when(httpResponse.statusMessage()).thenReturn("");
+    when(httpResponse.headers()).thenReturn(MultiMap.caseInsensitiveMultiMap());
+    when(httpResponse.trailers()).thenReturn(MultiMap.caseInsensitiveMultiMap());
+  }
+
+  private void whenRequestFailed() {
+    tested.onRequestCreation(endpointRequest);
+    tested.onRequestFailed(new IOException("Network error"));
+  }
+
+  private void whenResponseCodeTimeout() {
+    tested.onRequestCreation(endpointRequest);
+    tested.onRequestFailed(new TimeoutException());
+    tested.onResponseCodeUnsuccessful(new IOException("Unsuccessful response code"));
+  }
+
+  private void whenResponseCodeUnsuccessful() {
+    tested.onRequestCreation(endpointRequest);
+    tested.onRequestSucceeded(httpResponse);
+    tested.onResponseCodeUnsuccessful(new IOException("Unsuccessful response code"));
+  }
+
+  private void whenResponseProcessingFailed() {
+    tested.onRequestCreation(endpointRequest);
+    tested.onRequestSucceeded(httpResponse);
+    tested.onResponseProcessingFailed(new IOException("Invalid response code"));
+  }
+
+  private void whenUnexpectedErrorAfterResponseProcessing() {
+    tested.onRequestCreation(endpointRequest);
+    tested.onRequestSucceeded(httpResponse);
+    tested.onResponseCodeSuccessful();
+    tested.onDifferentError(new NullPointerException("Internal reference null"));
+  }
+
+  private void thenLogContainsRequestData(boolean positive) {
+    JsonObject logs = tested.getJsonNodeLog().getJsonObject("logs");
+    if (positive) {
+      assertNotNull(logs.getJsonObject(REQUEST));
+      assertRequestLogs(logs.getJsonObject(REQUEST));
+    } else {
+      assertNull(logs.getJsonObject(REQUEST));
+    }
+  }
+
+  private void thenLogContainsResponse(boolean positive) {
+    JsonObject logs = tested.getJsonNodeLog().getJsonObject("logs");
+    if (positive) {
+      assertNotNull(logs.getJsonObject(RESPONSE));
+      assertResponseLogs(logs.getJsonObject(RESPONSE));
+    } else {
+      assertNull(logs.getJsonObject(RESPONSE));
+    }
+  }
+
+  private void thenLogContainsResponseBody(boolean positive) {
+    JsonObject logs = tested.getJsonNodeLog().getJsonObject("logs");
+    if (positive) {
+      assertNotNull(logs.getString(RESPONSE_BODY));
+    } else {
+      assertNull(logs.getString(RESPONSE_BODY));
+    }
+  }
+
+  private void thenLogContainsError(boolean positive) {
+    JsonObject logs = tested.getJsonNodeLog().getJsonObject("logs");
+    if (positive) {
+      assertNotNull(logs.getJsonArray(ERRORS));
+      assertErrorLogs(logs.getJsonArray(ERRORS));
+    } else {
+      assertNull(logs.getJsonArray(ERRORS));
+    }
+  }
+
+  private static void assertRequestLogs(JsonObject requestLog) {
+    assertTrue(requestLog.containsKey("path"));
+    assertTrue(requestLog.containsKey("requestHeaders"));
+  }
+
+  private static void assertErrorLogs(JsonArray errorLog) {
+    errorLog.forEach(e -> {
+      ((JsonObject) e).containsKey("className");
+      ((JsonObject) e).containsKey("message");
+    });
+  }
+
+  private static void assertResponseLogs(JsonObject responseLog) {
+    assertTrue(responseLog.containsKey("httpVersion"));
+    assertTrue(responseLog.containsKey("httpMethod"));
+    assertTrue(responseLog.containsKey("statusCode"));
+    assertTrue(responseLog.containsKey("statusMessage"));
+    assertTrue(responseLog.containsKey("headers"));
+    assertTrue(responseLog.containsKey("trailers"));
+    assertTrue(responseLog.containsKey("requestPath"));
+  }
+
+}

--- a/handler/api/src/main/java/io/knotx/fragments/handler/api/actionlog/ActionLogLevel.java
+++ b/handler/api/src/main/java/io/knotx/fragments/handler/api/actionlog/ActionLogLevel.java
@@ -36,17 +36,21 @@ public enum ActionLogLevel {
     return level;
   }
 
+  public static ActionLogLevel fromConfig(JsonObject config) {
+    return fromConfig(config.getString(CONFIG_KEY_NAME, ERROR.level));
+  }
+
   public static ActionLogLevel fromConfig(JsonObject config, ActionLogLevel defaultLevel) {
     String level = config.getString(CONFIG_KEY_NAME);
+    return fromConfig(level, defaultLevel);
+  }
+
+  public static ActionLogLevel fromConfig(String level, ActionLogLevel defaultLevel) {
     if (StringUtils.isBlank(level)) {
       return defaultLevel;
     } else {
       return fromConfig(level);
     }
-  }
-
-  public static ActionLogLevel fromConfig(JsonObject config) {
-    return fromConfig(config.getString(CONFIG_KEY_NAME, ERROR.level));
   }
 
   public static ActionLogLevel fromConfig(String level) {

--- a/handler/api/src/main/java/io/knotx/fragments/handler/api/domain/payload/ActionPayload.java
+++ b/handler/api/src/main/java/io/knotx/fragments/handler/api/domain/payload/ActionPayload.java
@@ -21,13 +21,13 @@ import io.vertx.core.json.JsonObject;
 @DataObject
 public class ActionPayload {
 
-  static final String RESULT_KEY = "_result";
+  private static final String RESULT_KEY = "_result";
 
   private final ActionRequest request;
   private final ActionResponse response;
   private final Object result;
 
-  ActionPayload(ActionRequest request, ActionResponse response, Object result) {
+  private ActionPayload(ActionRequest request, ActionResponse response, Object result) {
     this.request = request;
     this.response = response;
     this.result = result;
@@ -39,12 +39,20 @@ public class ActionPayload {
     this.result = jsonObject.getValue(RESULT_KEY);
   }
 
+  public static ActionPayload create(ActionRequest request, ActionResponse response, Object result) {
+    return new ActionPayload(request, response, result);
+  }
+
   public static ActionPayload success(ActionRequest request, Object result) {
     return new ActionPayload(request, ActionResponse.success(), result);
   }
 
   public static ActionPayload error(ActionRequest request, String errorCode, String errorMessage) {
     return new ActionPayload(request, ActionResponse.error(errorCode, errorMessage), null);
+  }
+
+  public static ActionPayload noResult(ActionRequest request, ActionResponse response) {
+    return new ActionPayload(request, response, null);
   }
 
   public JsonObject toJson() {


### PR DESCRIPTION
## Description
HttpAction has a tremendous amount of responsibility. It is also long (almost 400 lines) and tangled.
This PR provides seperation of responsibilities fot HttpAction.

Alongside these changes, this PR introduces WebClientCache for HttpActionFactory.
The cache takes WebClientOptions (parsed to JSON) as key.
Also, the HttpActionFactory is not annotated as @Cacheable, so HttpAction instances can be reused between requests.

## Motivation and Context
References #72 #73 
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Upgrade notes (if appropriate)

Request and response headers have been logged in as plain values. This changes in this PR to JSONArray() to reflect the actual MutliMap nature of HTTP Headers. This is a minor change, but may require adjustments in tools processing the HttpAction's logs.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](/CONTRIBUTING.md#coding-conventions) of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

---
I hereby agree to the terms of the Knot.x Contributor License Agreement.
