### PR TITLE
KnotxServer response configuration - wildcards test, case-insensitive filtering allowed headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to `knotx-fragments` will be documented in this file.
 
 ## Unreleased
 List of changes that are finished but not yet released in any final version.
+- [PR-100](https://github.com/Knotx/knotx-fragments/pull/100) - KnotxServer response configuration - wildcards, case-insensitive filtering allowed headers
 - [PR-96](https://github.com/Knotx/knotx-fragments/pull/96) - HttpAction in knotx-fragments. Actions moved to a new module `knotx-fragments-handler-actions`.
 - [PR-80](https://github.com/Knotx/knotx-fragments/pull/80) - Circuit breaker understands which custom transition mean error.
 - [PR-84](https://github.com/Knotx/knotx-fragments/pull/84) - Adding node log to inline payload action.

--- a/handler/actions/src/main/java/io/knotx/fragments/handler/action/http/request/EndpointRequestComposer.java
+++ b/handler/actions/src/main/java/io/knotx/fragments/handler/action/http/request/EndpointRequestComposer.java
@@ -24,6 +24,7 @@ import io.knotx.server.common.placeholders.PlaceholdersResolver;
 import io.knotx.server.common.placeholders.SourceDefinitions;
 import io.vertx.reactivex.core.MultiMap;
 import java.util.List;
+import java.util.Set;
 import java.util.regex.Pattern;
 
 public class EndpointRequestComposer {
@@ -58,7 +59,7 @@ public class EndpointRequestComposer {
 
   private MultiMap getRequestHeaders(ClientRequest clientRequest) {
     MultiMap filteredHeaders = getFilteredHeaders(clientRequest.getHeaders(),
-        endpointOptions.getAllowedRequestHeadersPatterns());
+        endpointOptions.getAllowedRequestHeaders());
     if (endpointOptions.getAdditionalHeaders() != null) {
       endpointOptions.getAdditionalHeaders()
           .forEach(entry -> filteredHeaders.add(entry.getKey(), entry.getValue().toString()));
@@ -66,9 +67,9 @@ public class EndpointRequestComposer {
     return filteredHeaders;
   }
 
-  private MultiMap getFilteredHeaders(MultiMap headers, List<Pattern> allowedHeaders) {
+  private MultiMap getFilteredHeaders(MultiMap headers, Set<String> allowedHeaders) {
     return headers.names().stream()
-        .filter(AllowedHeadersFilter.create(allowedHeaders))
+        .filter(AllowedHeadersFilter.CaseInsensitive.create(allowedHeaders))
         .collect(MultiMapCollector.toMultiMap(o -> o, headers::getAll));
   }
 

--- a/handler/actions/src/test/java/io/knotx/fragments/handler/action/http/HttpActionTest.java
+++ b/handler/actions/src/test/java/io/knotx/fragments/handler/action/http/HttpActionTest.java
@@ -52,13 +52,13 @@ import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import io.vertx.reactivex.core.MultiMap;
 import io.vertx.reactivex.ext.web.client.WebClient;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
-import java.util.regex.Pattern;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -92,6 +92,7 @@ class HttpActionTest {
       "  \"url\": \"http://knotx.io\",\n" +
       "  \"label\": \"Product\"\n" +
       "}";
+  private static final Set<String> ALLOW_ALL_HEADERS = Collections.singleton(".*");
   private static final JsonObject EMPTY_JSON = new JsonObject();
 
   private WireMockServer wireMockServer;
@@ -538,7 +539,7 @@ class HttpActionTest {
         .setPath("not-existing-endpoint")
         .setDomain("localhost")
         .setPort(wireMockServer.port())
-        .setAllowedRequestHeaderPatterns(Collections.singletonList(Pattern.compile(".*")));
+        .setAllowedRequestHeaders(ALLOW_ALL_HEADERS);
 
     HttpAction tested = new HttpAction(createDefaultWebClient(vertx),
         new HttpActionOptions().setEndpointOptions(endpointOptions)
@@ -629,7 +630,7 @@ class HttpActionTest {
         .setPath(optionsPath)
         .setDomain("localhost")
         .setPort(wireMockServer.port())
-        .setAllowedRequestHeaderPatterns(Collections.singletonList(Pattern.compile(".*")));
+        .setAllowedRequestHeaders(ALLOW_ALL_HEADERS);
 
     HttpAction tested = new HttpAction(createDefaultWebClient(vertx),
         new HttpActionOptions().setEndpointOptions(endpointOptions)
@@ -662,7 +663,7 @@ class HttpActionTest {
         .setPath(optionsPath)
         .setDomain("localhost")
         .setPort(wireMockServer.port())
-        .setAllowedRequestHeaderPatterns(Collections.singletonList(Pattern.compile(".*")));
+        .setAllowedRequestHeaders(ALLOW_ALL_HEADERS);
 
     HttpAction tested = new HttpAction(createDefaultWebClient(vertx),
         new HttpActionOptions().setEndpointOptions(endpointOptions)
@@ -693,7 +694,7 @@ class HttpActionTest {
         .setPath(optionsPath)
         .setDomain("localhost")
         .setPort(wireMockServer.port())
-        .setAllowedRequestHeaderPatterns(Collections.singletonList(Pattern.compile(".*")));
+        .setAllowedRequestHeaders(ALLOW_ALL_HEADERS);
 
     HttpAction tested = new HttpAction(createDefaultWebClient(vertx),
         new HttpActionOptions().setEndpointOptions(endpointOptions)
@@ -724,7 +725,7 @@ class HttpActionTest {
         .setPath(optionsPath)
         .setDomain("localhost")
         .setPort(wireMockServer.port())
-        .setAllowedRequestHeaderPatterns(Collections.singletonList(Pattern.compile(".*")));
+        .setAllowedRequestHeaders(ALLOW_ALL_HEADERS);
 
     HttpAction tested = new HttpAction(createDefaultWebClient(vertx),
         new HttpActionOptions().setEndpointOptions(endpointOptions)
@@ -777,7 +778,7 @@ class HttpActionTest {
         .setPath(HttpActionTest.VALID_REQUEST_PATH)
         .setDomain("localhost")
         .setPort(wireMockServer.port())
-        .setAllowedRequestHeaderPatterns(Collections.singletonList(Pattern.compile(".*")))
+        .setAllowedRequestHeaders(ALLOW_ALL_HEADERS)
         .setAdditionalHeaders(additionalHeaders);
 
     return new HttpAction(createDefaultWebClient(vertx),
@@ -796,7 +797,7 @@ class HttpActionTest {
         .setPath(endpointPath)
         .setDomain("localhost")
         .setPort(wireMockServer.port())
-        .setAllowedRequestHeaderPatterns(Collections.singletonList(Pattern.compile(".*")));
+        .setAllowedRequestHeaders(ALLOW_ALL_HEADERS);
 
     Optional.ofNullable(jsonPredicate).ifPresent(predicates::add);
     ResponseOptions responseOptions = new ResponseOptions()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
For a reason we can use:
```
AllowedHeadersFilter.CaseInsensitive.create(strings);
```
I done refactor usage of AllowedHeadersFilter

I also found one thing that worries me. In ```EndpointOptions``` we can also set:
```
private JsonObject additionalHeaders;
private List<Pattern> allowedRequestHeadersPatterns;
```
by provided setter. But if we use only ```setAllowedRequestHeaderPatterns```, we don't fixing value of additionalHeaders. But in the other way, if we use ```setAllowedRequestHeaders``` we also set correct value for allowedRequestHeadersPatterns. In my opinion we should make setAllowedRequestHeaderPatterns private, or even skip this concept. @Skejven @tomaszmichalak  what is your opinion about that ?


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
### knotx-commons
[#7](https://github.com/Knotx/knotx-commons/issues/7) and [PR-8](https://github.com/Knotx/knotx-commons/pull/8)
### knotx-server-http
[#41](https://github.com/Knotx/knotx-server-http/issues/41)

## Screenshots (if appropriate)

## Upgrade notes (if appropriate)
<!-- What changes user have to do in order to migrate from the previous version to the version with this feature -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](/CONTRIBUTING.md#coding-conventions) of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---
I hereby agree to the terms of the Knot.x Contributor License Agreement.
