### PR TITLE
 #114 Replace computeIfAbsent with custom logic

### DIFF
--- a/actions/core/src/main/java/io/knotx/fragments/action/ActionProvider.java
+++ b/actions/core/src/main/java/io/knotx/fragments/action/ActionProvider.java
@@ -91,15 +91,18 @@ public class ActionProvider {
     }
 
     if (isCacheable(factory)) {
-      return Optional.of(cache.computeIfAbsent(alias, toAction(actionFactoryOptions, factory)));
+      return Optional.ofNullable(cache.get(alias))
+          .map(Optional::of)
+          .orElseGet(() -> Optional.ofNullable(createAction(alias, actionFactoryOptions, factory)))
+          .map(createdAction -> cacheIfAbsent(alias, createdAction));
     } else {
       return Optional.of(createAction(alias, actionFactoryOptions, factory));
     }
   }
 
-  private Function<String, Action> toAction(ActionFactoryOptions actionFactoryOptions,
-      ActionFactory factory) {
-    return action -> createAction(action, actionFactoryOptions, factory);
+  private Action cacheIfAbsent(String key, Action action) {
+    cache.putIfAbsent(key, action);
+    return action;
   }
 
   private Action createAction(String action, ActionFactoryOptions actionFactoryOptions,


### PR DESCRIPTION
## Description
Removed `HashMap#computeIfAbset` that was causing the bug.

## Motivation and Context
https://github.com/Knotx/knotx-fragments/issues/114

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](/CONTRIBUTING.md#coding-conventions) of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---
I hereby agree to the terms of the Knot.x Contributor License Agreement.
