### PR TITLE
#73 Support HTTP methods and sending body for POST/PATCH/PUT requests.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to `knotx-fragments` will be documented in this file.
 
 ## Unreleased
 List of changes that are finished but not yet released in any final version.
+- [PR-120](https://github.com/Knotx/knotx-fragments/pull/120) - HTTP methods for HttpAction - support for POST/PUT/PATCH/DELETE/HEAD and sending body.
 - [PR-100](https://github.com/Knotx/knotx-fragments/pull/100) - KnotxServer response configuration - wildcards, case-insensitive filtering allowed headers
 - [PR-96](https://github.com/Knotx/knotx-fragments/pull/96) - HttpAction in knotx-fragments. Actions moved to a new module `knotx-fragments-handler-actions`.
 - [PR-80](https://github.com/Knotx/knotx-fragments/pull/80) - Circuit breaker understands which custom transition mean error.

--- a/handler/actions/README.md
+++ b/handler/actions/README.md
@@ -93,7 +93,8 @@ Node log is presented as `JSON` and has the following structure:
   "path": "/api/endpoint",
   "requestHeaders": {
     "Content-Type": "application/json"
-  }
+  },
+  "requestBody": ""
 }
 ```
 `RESPONSE_DATA` contains the following entries:
@@ -136,6 +137,19 @@ The table below presents expected entries in node log on particular log levels d
 | exception occurs and `_error`              | ERROR      | REQUEST_DATA, LIST_OF_ERRORS               |
 | `_error` (e.g service responds with `500`) | INFO       | REQUEST_DATA, RESPONSE_DATA, RESPONSE_BODY |
 | `_error` (e.g service responds with `500`) | INFO       | REQUEST_DATA, RESPONSE_DATA                |
+
+#### Supported HTTP methods
+
+Currently Knot.x supports `GET`, `POST`, `PUT`, `PATCH`, `DELETE` and `HEAD` HTTP methods.
+This is specified using `httpMethod` option under `config` node of HttpAction (defaults to `GET`).
+
+For `POST`, `PUT` and `PATCH` methods, request body is send. 
+Body can be specified either as String or as a JSON, using `body` and `bodyJson` parameters under `endpointOptions`.
+In both cases, it is possible to perform interpolation based on the original request, Fragment's configuration or Fragment's payload.
+For details, see [Knot.x Server Common Placeholders](https://github.com/Knotx/knotx-server-http/tree/master/common/placeholders#available-request-placeholders-support).
+Please note that unlike for path, placeholder values put into body are not URL-encoded.
+ 
+To enable body interpolation, set `interpolateBody` flag under `endpointOptions` to `true`.
 
 #### Detailed configuration
 All configuration options are explained in details in the [Config Options Cheetsheet](https://github.com/Knotx/knotx-fragments/tree/master/handler/core/docs/asciidoc/dataobjects.adoc).

--- a/handler/actions/docs/asciidoc/dataobjects.adoc
+++ b/handler/actions/docs/asciidoc/dataobjects.adoc
@@ -42,11 +42,46 @@ Sets the additional request headers (and values) to be send in each request
 Sets the allowed requests headers that should be send to the service. The selected headers from
  the original client HTTP request are being send.
 +++
+|[[body]]`@body`|`String`|+++
+Sets the request body schema to be sent to the endpoint. The body may contain <a
+ href="https://github.com/Knotx/knotx-server-http/tree/master/common/placeholders">Knot.x Server
+ Common Placeholders</a> referencing ClientRequest, Fragment's configuration or Fragment's
+ payload, which will be interpolated if link flag is set.
+
+ Please note that request body is sent only in case of using PUT, POST or PATCH HTTP method.
+
+ This field is mutually exclusive with link.
++++
+|[[bodyJson]]`@bodyJson`|`Json object`|+++
+Sets the request body schema to be sent to the endpoint. The body may contain <a
+ href="https://github.com/Knotx/knotx-server-http/tree/master/common/placeholders">Knot.x Server
+ Common Placeholders</a> referencing ClientRequest, Fragment's configuration or Fragment's
+ payload, which will be interpolated if link flag is set.
+
+ Please note that request body is sent only in case of using PUT, POST or PATCH HTTP method.
+
+ This field is mutually exclusive with link.
++++
 |[[domain]]`@domain`|`String`|+++
 Sets the <code>domain</code> of the external service
 +++
+|[[interpolateBody]]`@interpolateBody`|`Boolean`|+++
+Configures interpolation of link parameter. When set, the body will be
+ interpolated using <a href="https://github.com/Knotx/knotx-server-http/tree/master/common/placeholders">Knot.x
+ Server Common Placeholders</a> referencing ClientRequest, Fragment's configuration or
+ Fragment's payload.
++++
+|[[interpolatePath]]`@interpolatePath`|`Boolean`|+++
+Configures interpolation of link parameter. When set, the path will be
+ interpolated using <a href="https://github.com/Knotx/knotx-server-http/tree/master/common/placeholders">Knot.x
+ Server Common Placeholders</a> referencing ClientRequest, Fragment's configuration or
+ Fragment's payload.
++++
 |[[path]]`@path`|`String`|+++
-Sets the request path to the endpoint.
+Sets the request path to the endpoint. The request path may contain <a
+ href="https://github.com/Knotx/knotx-server-http/tree/master/common/placeholders">Knot.x Server
+ Common Placeholders</a> referencing ClientRequest, Fragment's configuration or Fragment's
+ payload.
 +++
 |[[port]]`@port`|`Number (int)`|+++
 Sets the HTTP <code>port</code> the external service
@@ -70,7 +105,8 @@ Set the details of the remote http endpoint location.
 +++
 |[[httpMethod]]`@httpMethod`|`String`|+++
 Set the <code>HttpMethod</code> used for performing the request.
- At the moment only HTTP GET method is supported.
+ Defaults to GET.
+ Supported methods are GET, POST, PATCH, PUT, DELETE and HEAD.
 +++
 |[[logLevel]]`@logLevel`|`String`|+++
 Set level of action logs.

--- a/handler/actions/src/main/java/io/knotx/fragments/handler/action/InMemoryCacheActionFactory.java
+++ b/handler/actions/src/main/java/io/knotx/fragments/handler/action/InMemoryCacheActionFactory.java
@@ -191,7 +191,7 @@ public class InMemoryCacheActionFactory implements ActionFactory {
     if (StringUtils.isBlank(key)) {
       throw new IllegalArgumentException("Action requires cacheKey value in configuration.");
     }
-    return PlaceholdersResolver.resolve(key, buildSourceDefinitions(clientRequest));
+    return PlaceholdersResolver.resolveAndEncode(key, buildSourceDefinitions(clientRequest));
   }
 
   private SourceDefinitions buildSourceDefinitions(ClientRequest clientRequest) {

--- a/handler/actions/src/main/java/io/knotx/fragments/handler/action/exception/ActionConfigurationException.java
+++ b/handler/actions/src/main/java/io/knotx/fragments/handler/action/exception/ActionConfigurationException.java
@@ -23,4 +23,8 @@ public class ActionConfigurationException extends ConfigurationException {
     super(actionAlias + ": " + message);
   }
 
+  public ActionConfigurationException(String actionAlias, String message, Throwable cause) {
+    super(actionAlias + ": " + message, cause);
+  }
+
 }

--- a/handler/actions/src/main/java/io/knotx/fragments/handler/action/http/HttpActionFactory.java
+++ b/handler/actions/src/main/java/io/knotx/fragments/handler/action/http/HttpActionFactory.java
@@ -15,17 +15,31 @@
  */
 package io.knotx.fragments.handler.action.http;
 
+import static io.vertx.core.http.HttpMethod.DELETE;
+import static io.vertx.core.http.HttpMethod.GET;
+import static io.vertx.core.http.HttpMethod.HEAD;
+import static io.vertx.core.http.HttpMethod.PATCH;
+import static io.vertx.core.http.HttpMethod.POST;
+import static io.vertx.core.http.HttpMethod.PUT;
+
+import com.google.common.collect.ImmutableSet;
 import io.knotx.fragments.handler.action.exception.ActionConfigurationException;
 import io.knotx.fragments.handler.action.http.options.HttpActionOptions;
 import io.knotx.fragments.handler.api.Action;
 import io.knotx.fragments.handler.api.ActionFactory;
 import io.knotx.fragments.handler.api.Cacheable;
 import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpMethod;
 import io.vertx.core.json.JsonObject;
 import io.vertx.reactivex.ext.web.client.WebClient;
+import java.util.Set;
+import java.util.stream.Stream;
 
 @Cacheable
 public class HttpActionFactory implements ActionFactory {
+
+  private static final Set<HttpMethod> SUPPORTED_METHODS = ImmutableSet
+      .of(GET, POST, PATCH, PUT, DELETE, HEAD);
 
   private final WebClientCache webClientCache = new WebClientCache();
 
@@ -36,20 +50,44 @@ public class HttpActionFactory implements ActionFactory {
 
   @Override
   public Action create(String alias, JsonObject config, Vertx vertx, Action doAction) {
+    HttpActionOptions options = new HttpActionOptions(config);
+
+    validateNoDoAction(doAction, alias);
+    validateHttpMethodSupported(options, alias);
+
+    WebClient webClient = webClientCache.getOrCreate(vertx, options.getWebClientOptions());
+    return tryToCreateAction(webClient, options, alias);
+  }
+
+  private void validateNoDoAction(Action doAction, String alias) {
     if (doAction != null) {
       throw new ActionConfigurationException(alias, "Http Action can not wrap another action");
     }
+  }
 
-    HttpActionOptions options = new HttpActionOptions(config);
+  private void validateHttpMethodSupported(HttpActionOptions options, String alias) {
+    HttpMethod method = findHttpMethod(options.getHttpMethod(), alias);
+    if (!SUPPORTED_METHODS.contains(method)) {
+      throw new ActionConfigurationException(alias,
+          String.format("HttpMethod %s configured for HttpAction is not supported",
+              options.getHttpMethod()));
+    }
+  }
 
-    WebClient webClient = webClientCache.getOrCreate(vertx, options.getWebClientOptions());
+  private HttpMethod findHttpMethod(String methodName, String actionAlias) {
+    return Stream.of(HttpMethod.values())
+        .filter(httpMethod -> httpMethod.name().equalsIgnoreCase(methodName))
+        .findFirst()
+        .orElseThrow(() -> new ActionConfigurationException(actionAlias,
+            String.format("HttpMethod %s configured for HttpAction not found in Vert.x library",
+                methodName)));
+  }
 
-    switch (options.getHttpMethod()) {
-      case "GET":
-        return new HttpAction(webClient, options, alias);
-      default:
-        throw new ActionConfigurationException(alias,
-            "HttpMethod configured for HttpAction is not supported");
+  private Action tryToCreateAction(WebClient webClient, HttpActionOptions options, String alias) {
+    try {
+      return new HttpAction(webClient, options, alias);
+    } catch (IllegalArgumentException cause) {
+      throw new ActionConfigurationException(alias, "Creating HttpAction failed", cause);
     }
   }
 

--- a/handler/actions/src/main/java/io/knotx/fragments/handler/action/http/ResponsePredicatesProvider.java
+++ b/handler/actions/src/main/java/io/knotx/fragments/handler/action/http/ResponsePredicatesProvider.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.knotx.fragments.handler.action.http.request;
+package io.knotx.fragments.handler.action.http;
 
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;

--- a/handler/actions/src/main/java/io/knotx/fragments/handler/action/http/log/HttpActionLogger.java
+++ b/handler/actions/src/main/java/io/knotx/fragments/handler/action/http/log/HttpActionLogger.java
@@ -118,7 +118,8 @@ public class HttpActionLogger {
 
   private JsonObject getRequestData() {
     return new JsonObject().put("path", endpointRequest.getPath())
-        .put("requestHeaders", MultiMapTransformer.toJson(endpointRequest.getHeaders()));
+        .put("requestHeaders", MultiMapTransformer.toJson(endpointRequest.getHeaders()))
+        .put("requestBody", endpointRequest.getBody());
   }
 
   private JsonObject getResponseData() {

--- a/handler/actions/src/main/java/io/knotx/fragments/handler/action/http/options/EndpointOptions.java
+++ b/handler/actions/src/main/java/io/knotx/fragments/handler/action/http/options/EndpointOptions.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * Describes a physical details of HTTP service endpoint that Action will connect to.
@@ -32,11 +33,15 @@ import java.util.stream.Collectors;
 public class EndpointOptions {
 
   private String path;
+  private String body = StringUtils.EMPTY;
+  private JsonObject bodyJson = new JsonObject();
   private String domain;
   private int port;
   private Set<String> allowedRequestHeaders;
   private JsonObject additionalHeaders;
   private List<Pattern> allowedRequestHeadersPatterns;
+  private boolean interpolatePath = true;
+  private boolean interpolateBody = false;
   //ToDo: private Set<StatusCode> successStatusCodes;
 
   public EndpointOptions() {
@@ -45,11 +50,15 @@ public class EndpointOptions {
 
   public EndpointOptions(EndpointOptions other) {
     this.path = other.path;
+    this.body = other.body;
     this.domain = other.domain;
     this.port = other.port;
     this.allowedRequestHeaders = new HashSet<>(other.allowedRequestHeaders);
     this.allowedRequestHeadersPatterns = new ArrayList<>(other.allowedRequestHeadersPatterns);
     this.additionalHeaders = other.additionalHeaders.copy();
+    this.bodyJson = other.getBodyJson();
+    this.interpolatePath = other.isInterpolatePath();
+    this.interpolateBody = other.isInterpolateBody();
   }
 
   public EndpointOptions(JsonObject json) {
@@ -72,13 +81,60 @@ public class EndpointOptions {
   }
 
   /**
-   * Sets the request path to the endpoint.
+   * Sets the request path to the endpoint. The request path may contain <a
+   * href="https://github.com/Knotx/knotx-server-http/tree/master/common/placeholders">Knot.x Server
+   * Common Placeholders</a> referencing ClientRequest, Fragment's configuration or Fragment's
+   * payload.
    *
    * @param path an endpoint request path.
    * @return a reference to this, so the API can be used fluently
    */
   public EndpointOptions setPath(String path) {
     this.path = path;
+    return this;
+  }
+
+  public String getBody() {
+    return body;
+  }
+
+  /**
+   * Sets the request body schema to be sent to the endpoint. The body may contain <a
+   * href="https://github.com/Knotx/knotx-server-http/tree/master/common/placeholders">Knot.x Server
+   * Common Placeholders</a> referencing ClientRequest, Fragment's configuration or Fragment's
+   * payload, which will be interpolated if {@link EndpointOptions#interpolateBody} flag is set.
+   *
+   * Please note that request body is sent only in case of using PUT, POST or PATCH HTTP method.
+   *
+   * This field is mutually exclusive with {@link EndpointOptions#bodyJson}.
+   *
+   * @param body a body to be send to the endpoint
+   * @return a reference to this, so the API can be used fluently
+   */
+  public EndpointOptions setBody(String body) {
+    this.body = body;
+    return this;
+  }
+
+  public JsonObject getBodyJson() {
+    return bodyJson;
+  }
+
+  /**
+   * Sets the request body schema to be sent to the endpoint. The body may contain <a
+   * href="https://github.com/Knotx/knotx-server-http/tree/master/common/placeholders">Knot.x Server
+   * Common Placeholders</a> referencing ClientRequest, Fragment's configuration or Fragment's
+   * payload, which will be interpolated if {@link EndpointOptions#interpolateBody} flag is set.
+   *
+   * Please note that request body is sent only in case of using PUT, POST or PATCH HTTP method.
+   *
+   * This field is mutually exclusive with {@link EndpointOptions#body}.
+   *
+   * @param bodyJson a body to be send to the endpoint
+   * @return a reference to this, so the API can be used fluently
+   */
+  public EndpointOptions setBodyJson(JsonObject bodyJson) {
+    this.bodyJson = bodyJson;
     return this;
   }
 
@@ -168,4 +224,57 @@ public class EndpointOptions {
     this.allowedRequestHeadersPatterns = allowedRequestHeaderPatterns;
     return this;
   }
+
+  public boolean isInterpolatePath() {
+    return interpolatePath;
+  }
+
+  /**
+   * Configures interpolation of {@link EndpointOptions#path} parameter. When set, the path will be
+   * interpolated using <a href="https://github.com/Knotx/knotx-server-http/tree/master/common/placeholders">Knot.x
+   * Server Common Placeholders</a> referencing ClientRequest, Fragment's configuration or
+   * Fragment's payload.
+   *
+   * @param interpolatePath flag enabling path interpolation
+   * @return a reference to this, so the API can be used fluently
+   */
+  public EndpointOptions setInterpolatePath(boolean interpolatePath) {
+    this.interpolatePath = interpolatePath;
+    return this;
+  }
+
+  public boolean isInterpolateBody() {
+    return interpolateBody;
+  }
+
+  /**
+   * Configures interpolation of {@link EndpointOptions#body} parameter. When set, the body will be
+   * interpolated using <a href="https://github.com/Knotx/knotx-server-http/tree/master/common/placeholders">Knot.x
+   * Server Common Placeholders</a> referencing ClientRequest, Fragment's configuration or
+   * Fragment's payload.
+   *
+   * @param interpolateBody flag enabling body interpolation
+   * @return a reference to this, so the API can be used fluently
+   */
+  public EndpointOptions setInterpolateBody(boolean interpolateBody) {
+    this.interpolateBody = interpolateBody;
+    return this;
+  }
+
+  @Override
+  public String toString() {
+    return "EndpointOptions{" +
+        "path='" + path + '\'' +
+        ", body='" + body + '\'' +
+        ", bodyJson=" + bodyJson +
+        ", domain='" + domain + '\'' +
+        ", port=" + port +
+        ", allowedRequestHeaders=" + allowedRequestHeaders +
+        ", additionalHeaders=" + additionalHeaders +
+        ", allowedRequestHeadersPatterns=" + allowedRequestHeadersPatterns +
+        ", interpolatePath=" + interpolatePath +
+        ", interpolateBody=" + interpolateBody +
+        '}';
+  }
+
 }

--- a/handler/actions/src/main/java/io/knotx/fragments/handler/action/http/options/HttpActionOptions.java
+++ b/handler/actions/src/main/java/io/knotx/fragments/handler/action/http/options/HttpActionOptions.java
@@ -48,7 +48,8 @@ public class HttpActionOptions {
 
   /**
    * Set the {@code HttpMethod} used for performing the request.
-   * At the moment only HTTP GET method is supported.
+   * Defaults to GET.
+   * Supported methods are GET, POST, PATCH, PUT, DELETE and HEAD.
    *
    * @param httpMethod HTTP method
    * @return a reference to this, so the API can be used fluently
@@ -134,11 +135,13 @@ public class HttpActionOptions {
   @Override
   public String toString() {
     return "HttpActionOptions{" +
-        "webClientOptions=" + webClientOptions +
+        "httpMethod='" + httpMethod + '\'' +
+        ", webClientOptions=" + webClientOptions +
         ", endpointOptions=" + endpointOptions +
         ", responseOptions=" + responseOptions +
         ", requestTimeoutMs=" + requestTimeoutMs +
-        ", logLevel=" + logLevel +
+        ", logLevel='" + logLevel + '\'' +
         '}';
   }
+
 }

--- a/handler/actions/src/main/java/io/knotx/fragments/handler/action/http/request/BodyComposer.java
+++ b/handler/actions/src/main/java/io/knotx/fragments/handler/action/http/request/BodyComposer.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2019 Knot.x Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.knotx.fragments.handler.action.http.request;
+
+import io.knotx.fragments.handler.action.http.options.EndpointOptions;
+import io.vertx.core.json.JsonObject;
+import org.apache.commons.lang3.StringUtils;
+
+class BodyComposer {
+
+  private final String body;
+  private final JsonObject bodyJson;
+  private final boolean interpolateBody;
+
+  BodyComposer(EndpointOptions endpointOptions) {
+    this.body = endpointOptions.getBody();
+    this.bodyJson = endpointOptions.getBodyJson();
+    this.interpolateBody = endpointOptions.isInterpolateBody();
+    ensureAtMostOneBodyConfiguration();
+  }
+
+  private void ensureAtMostOneBodyConfiguration() {
+    if (StringUtils.isNotBlank(body) && !bodyJson.isEmpty()) {
+      throw new IllegalArgumentException(
+          "Ambiguous body parameter - both body and bodyJson specified.");
+    }
+  }
+
+  String getBody(EndpointPlaceholdersResolver resolver) {
+    if (interpolateBody) {
+      return getInterpolatedBody(resolver);
+    } else {
+      return getPlainBody();
+    }
+  }
+
+  boolean shouldUseJsonBody() {
+    return !bodyJson.isEmpty();
+  }
+
+  private String getInterpolatedBody(EndpointPlaceholdersResolver resolver) {
+    if (shouldUseJsonBody()) {
+      return resolver.resolve(bodyJson).toString();
+    } else {
+      return resolver.resolve(body);
+    }
+  }
+
+  private String getPlainBody() {
+    if (shouldUseJsonBody()) {
+      return bodyJson.toString();
+    } else {
+      return body;
+    }
+  }
+
+}

--- a/handler/actions/src/main/java/io/knotx/fragments/handler/action/http/request/EndpointPlaceholdersResolver.java
+++ b/handler/actions/src/main/java/io/knotx/fragments/handler/action/http/request/EndpointPlaceholdersResolver.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2019 Knot.x Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.knotx.fragments.handler.action.http.request;
+
+import io.knotx.fragments.api.FragmentContext;
+import io.knotx.server.common.placeholders.PlaceholdersResolver;
+import io.knotx.server.common.placeholders.SourceDefinitions;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import org.apache.commons.lang3.StringUtils;
+
+class EndpointPlaceholdersResolver {
+
+  private static final String PLACEHOLDER_PREFIX_PAYLOAD = "payload";
+  private static final String PLACEHOLDER_PREFIX_CONFIG = "config";
+
+  private final SourceDefinitions sourceDefinitions;
+
+  EndpointPlaceholdersResolver(FragmentContext fragmentContext) {
+    sourceDefinitions = buildSourceDefinitions(fragmentContext);
+  }
+
+  String resolve(String input) {
+    return PlaceholdersResolver.resolve(input, sourceDefinitions);
+  }
+
+  JsonObject resolve(JsonObject input) {
+    JsonObject output = new JsonObject();
+    input.forEach(entry -> output.put(resolveNotEmpty(entry.getKey()), resolveInternal(entry.getValue())));
+    return output;
+  }
+
+  String resolveAndEncode(String input) {
+    return PlaceholdersResolver.resolveAndEncode(input, sourceDefinitions);
+  }
+
+  private SourceDefinitions buildSourceDefinitions(FragmentContext context) {
+    return SourceDefinitions.builder()
+        .addClientRequestSource(context.getClientRequest())
+        .addJsonObjectSource(context.getFragment()
+            .getPayload(), PLACEHOLDER_PREFIX_PAYLOAD)
+        .addJsonObjectSource(context.getFragment()
+            .getConfiguration(), PLACEHOLDER_PREFIX_CONFIG)
+        .build();
+  }
+
+  private String resolveNotEmpty(String input) {
+    return Optional.of(input)
+        .map(this::resolve)
+        .filter(StringUtils::isNotEmpty)
+        .orElseThrow(() -> new IllegalStateException(
+            String.format("Resolving [%s] resulted in a forbidden empty string", input)));
+  }
+
+  private Object resolveInternal(Object object) {
+    if (object instanceof JsonObject) {
+      return resolve((JsonObject) object);
+    } else if (object instanceof JsonArray) {
+      JsonArray array = (JsonArray) object;
+      List<Object> list = array.stream().map(this::resolveInternal).collect(Collectors.toList());
+      return new JsonArray(list);
+    } else if (object instanceof String) {
+      return PlaceholdersResolver.resolve((String) object, sourceDefinitions);
+    } else {
+      return object;
+    }
+  }
+
+}

--- a/handler/actions/src/main/java/io/knotx/fragments/handler/action/http/request/EndpointRequest.java
+++ b/handler/actions/src/main/java/io/knotx/fragments/handler/action/http/request/EndpointRequest.java
@@ -16,15 +16,22 @@
 package io.knotx.fragments.handler.action.http.request;
 
 import io.vertx.reactivex.core.MultiMap;
+import org.apache.commons.lang3.StringUtils;
 
 public class EndpointRequest {
 
   private final String path;
   private final MultiMap headers;
+  private final String body;
 
   public EndpointRequest(String path, MultiMap headers) {
+    this(path, headers, StringUtils.EMPTY);
+  }
+
+  public EndpointRequest(String path, MultiMap headers, String body) {
     this.path = path;
     this.headers = headers;
+    this.body = body;
   }
 
   public String getPath() {
@@ -33,6 +40,10 @@ public class EndpointRequest {
 
   public MultiMap getHeaders() {
     return headers;
+  }
+
+  public String getBody() {
+    return body;
   }
 
 }

--- a/handler/actions/src/main/java/io/knotx/fragments/handler/action/http/request/HeadersComposer.java
+++ b/handler/actions/src/main/java/io/knotx/fragments/handler/action/http/request/HeadersComposer.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2019 Knot.x Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.knotx.fragments.handler.action.http.request;
+
+import io.knotx.commons.http.request.AllowedHeadersFilter;
+import io.knotx.commons.http.request.MultiMapCollector;
+import io.knotx.fragments.handler.action.http.options.EndpointOptions;
+import io.knotx.server.api.context.ClientRequest;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpHeaderValues;
+import io.vertx.core.json.JsonObject;
+import io.vertx.reactivex.core.MultiMap;
+import java.util.Optional;
+import java.util.Set;
+
+class HeadersComposer {
+
+  private final JsonObject additionalHeaders;
+  private final Set<String> allowedHeaders;
+
+  HeadersComposer(EndpointOptions endpointOptions) {
+    this.additionalHeaders = endpointOptions.getAdditionalHeaders();
+    this.allowedHeaders = endpointOptions.getAllowedRequestHeaders();
+  }
+
+  MultiMap getRequestHeaders(ClientRequest clientRequest) {
+    return Optional.of(clientRequest.getHeaders())
+        .map(this::getFilteredHeaders)
+        .map(this::addAdditionalHeaders)
+        .orElseGet(MultiMap::caseInsensitiveMultiMap);
+  }
+
+  void setJsonContentTypeIfEmpty(MultiMap requestHeaders) {
+    if(!requestHeaders.contains(HttpHeaderNames.CONTENT_TYPE)) {
+      requestHeaders.add(HttpHeaderNames.CONTENT_TYPE, HttpHeaderValues.APPLICATION_JSON);
+    }
+  }
+
+  private MultiMap getFilteredHeaders(MultiMap headers) {
+    return headers.names().stream()
+        .filter(AllowedHeadersFilter.CaseInsensitive.create(allowedHeaders))
+        .collect(MultiMapCollector.toMultiMap(o -> o, headers::getAll));
+  }
+
+  private MultiMap addAdditionalHeaders(MultiMap headers) {
+    if (additionalHeaders != null) {
+      additionalHeaders.forEach(entry -> headers.add(entry.getKey(), entry.getValue().toString()));
+    }
+    return headers;
+  }
+}

--- a/handler/actions/src/main/java/io/knotx/fragments/handler/action/http/response/EndpointResponse.java
+++ b/handler/actions/src/main/java/io/knotx/fragments/handler/action/http/response/EndpointResponse.java
@@ -45,7 +45,6 @@ public class EndpointResponse {
     return endpointResponse;
   }
 
-
   HttpResponseStatus getStatusCode() {
     return statusCode;
   }

--- a/handler/actions/src/test/java/io/knotx/fragments/handler/action/http/EndpointInvokerTest.java
+++ b/handler/actions/src/test/java/io/knotx/fragments/handler/action/http/EndpointInvokerTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (C) 2019 Knot.x Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.knotx.fragments.handler.action.http;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.knotx.fragments.handler.action.http.options.HttpActionOptions;
+import io.knotx.fragments.handler.action.http.request.EndpointRequest;
+import io.reactivex.Single;
+import io.vertx.core.json.JsonObject;
+import io.vertx.reactivex.core.MultiMap;
+import io.vertx.reactivex.core.buffer.Buffer;
+import io.vertx.reactivex.ext.web.client.HttpRequest;
+import io.vertx.reactivex.ext.web.client.HttpResponse;
+import io.vertx.reactivex.ext.web.client.WebClient;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class EndpointInvokerTest {
+
+  private static final String SAMPLE_BODY = "{ \"token\": \"ousega@Q*#gsnls3\" }";
+
+  @Mock
+  private HttpRequest<Buffer> request;
+
+  @Mock
+  private HttpResponse<Buffer> response;
+
+  @Mock
+  private WebClient webClient;
+
+  @ParameterizedTest
+  @ValueSource(strings = {"GET", "HEAD", "DELETE"})
+  @DisplayName("Expect body not send when body not supported by HTTP method ")
+  void shouldNotSendBody(String httpMethod) {
+    // given
+    EndpointRequest endpointRequest = new EndpointRequest("/", MultiMap.caseInsensitiveMultiMap());
+    HttpActionOptions options = sampleOptionsFor(httpMethod);
+    mockHttpRequest(StringUtils.EMPTY);
+    mockWebClient();
+
+    EndpointInvoker tested = new EndpointInvoker(webClient, options);
+
+    // when
+    tested.invokeEndpoint(endpointRequest).subscribe();
+
+    // then
+    assertAll(
+        () -> verify(request, times(1)).rxSend(),
+        () -> verify(request, times(0)).rxSendBuffer(any())
+    );
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"POST", "PUT", "PATCH"})
+  @DisplayName("Expect body send when supported by HTTP method")
+  void shouldSendBody(String httpMethod) {
+    // given
+    EndpointRequest endpointRequest = new EndpointRequest("/", MultiMap.caseInsensitiveMultiMap(),
+        SAMPLE_BODY);
+    HttpActionOptions options = sampleOptionsFor(httpMethod);
+
+    mockHttpRequest(SAMPLE_BODY);
+    mockWebClient();
+
+    EndpointInvoker tested = new EndpointInvoker(webClient, options);
+
+    // when
+    tested.invokeEndpoint(endpointRequest).subscribe();
+
+    // then
+    assertAll(
+        () -> verify(request, times(0)).rxSend(),
+        () -> verify(request, times(1)).rxSendBuffer(Buffer.buffer(SAMPLE_BODY))
+    );
+  }
+
+  private HttpActionOptions sampleOptionsFor(String httpMethod) {
+    JsonObject configuration = new JsonObject()
+        .put("httpMethod", httpMethod)
+        .put("endpointOptions", new JsonObject()
+            .put("domain", "https://api.service.com")
+            .put("port", 8080));
+    return new HttpActionOptions(configuration);
+  }
+
+  private void mockWebClient() {
+    when(webClient.request(any(), anyInt(), any(), any())).thenReturn(request);
+  }
+
+  private void mockHttpRequest(String expectedBody) {
+    when(request.timeout(anyLong())).thenReturn(request);
+    when(request.putHeaders(any())).thenReturn(request);
+
+    lenient().when(request.rxSend()).thenReturn(Single.just(response));
+    lenient().when(request.rxSendBuffer(Buffer.buffer(expectedBody))).thenReturn(Single.just(response));
+  }
+
+}

--- a/handler/actions/src/test/java/io/knotx/fragments/handler/action/http/ResponsePredicatesProviderTest.java
+++ b/handler/actions/src/test/java/io/knotx/fragments/handler/action/http/ResponsePredicatesProviderTest.java
@@ -18,7 +18,6 @@ package io.knotx.fragments.handler.action.http;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import io.knotx.fragments.handler.action.http.request.ResponsePredicatesProvider;
 import io.vertx.reactivex.ext.web.client.predicate.ResponsePredicate;
 import java.util.stream.Stream;
 import org.junit.jupiter.params.ParameterizedTest;

--- a/handler/actions/src/test/java/io/knotx/fragments/handler/action/http/log/HttpActionLoggerTest.java
+++ b/handler/actions/src/test/java/io/knotx/fragments/handler/action/http/log/HttpActionLoggerTest.java
@@ -294,6 +294,7 @@ class HttpActionLoggerTest {
   private static void assertRequestLogs(JsonObject requestLog) {
     assertTrue(requestLog.containsKey("path"));
     assertTrue(requestLog.containsKey("requestHeaders"));
+    assertTrue(requestLog.containsKey("requestBody"));
   }
 
   private static void assertErrorLogs(JsonArray errorLog) {

--- a/handler/actions/src/test/java/io/knotx/fragments/handler/action/http/request/EndpointPlaceholdersResolverTest.java
+++ b/handler/actions/src/test/java/io/knotx/fragments/handler/action/http/request/EndpointPlaceholdersResolverTest.java
@@ -1,0 +1,232 @@
+/*
+ * Copyright (C) 2019 Knot.x Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.knotx.fragments.handler.action.http.request;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import io.knotx.fragments.api.Fragment;
+import io.knotx.fragments.api.FragmentContext;
+import io.knotx.server.api.context.ClientRequest;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.reactivex.core.MultiMap;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class EndpointPlaceholdersResolverTest {
+
+  private static final String HOST_HEADER = "domain.com";
+  private static final String REFINED_QUERY_PARAM = "someComplexValue";
+  private static final String HTTP_REQUEST_SOURCE = "/api/v1/stuff";
+  private static final String API_KEY = "SEousaebES73task4!@%Tyiq3tgs08#^w#JSNB";
+  private static final String ENCODED_API_KEY = "SEousaebES73task4%21%40%25Tyiq3tgs08%23%5Ew%23JSNB";
+
+  private static final String STRING_NO_PLACEHOLDERS = "<a href=\"http://www.some.page.com/path/page.html\">Some text with no placeholders</a>";
+  private static final String PAYLOAD_API_KEY_PLACEHOLDER = "{payload.api-key}";
+  private static final String STRING_WITH_PLACEHOLDERS =
+      "<a href=\"{header.host}\">{header.content-type}</a>"
+          + "<a href=\"{param.refinedQuery}\">{param.code}</a>"
+          + "<a href=\"{payload.httpCall._request.source}\">{payload.httpCall._result}</a>";
+  private static final String STRING_EMPTIED_PLACEHOLDERS = "<a href=\"\"></a><a href=\"\"></a><a href=\"\"></a>";
+  private static final String STRING_SOME_PLACEHOLDERS_FILLED_OTHER_EMPTIED =
+      "<a href=\"" + HOST_HEADER + "\"></a><a href=\"" + REFINED_QUERY_PARAM + "\"></a><a href=\""
+          + HTTP_REQUEST_SOURCE + "\"></a>";
+
+  private static final JsonObject JSON_NO_PLACEHOLDERS = new JsonObject()
+      .put("api-key", "^mJHG3%#r6@")
+      .put("items", new JsonObject()
+          .put("itemCount", 2)
+          .put("items", new JsonArray()
+              .add(new JsonObject().put("product1", "code-UYO"))
+              .add(new JsonObject().put("product2", "code-HYW"))));
+  private static final JsonObject JSON_SINGLE_PLACEHOLDER = new JsonObject()
+      .put("apiResponse", new JsonObject().put("apiKey", PAYLOAD_API_KEY_PLACEHOLDER));
+  private static final JsonObject JSON_SINGLE_PLACEHOLDER_FILLED = new JsonObject()
+      .put("apiResponse", new JsonObject().put("apiKey", API_KEY));
+  private static final JsonObject JSON_WITH_PLACEHOLDERS = new JsonObject()
+      .put("api-key", "{header.host}")
+      .put("items", new JsonObject()
+          .put("itemCount", 2)
+          .put("{param.refinedQuery}", new JsonArray()
+              .add(new JsonObject().put("product1", "{payload.httpCall._request.source}"))
+              .add(new JsonObject().put("product2", "code-HYW"))));
+  private static final JsonObject JSON_WITH_FILLED_PLACEHOLDERS = new JsonObject()
+      .put("api-key", HOST_HEADER)
+      .put("items", new JsonObject()
+          .put("itemCount", 2)
+          .put(REFINED_QUERY_PARAM, new JsonArray()
+              .add(new JsonObject().put("product1", HTTP_REQUEST_SOURCE))
+              .add(new JsonObject().put("product2", "code-HYW"))));
+  private static final JsonObject JSON_NONEXISTENT_KEY_PLACEHOLDERS = new JsonObject()
+      .put("api-key", "^mJHG3%#r6@")
+      .put("nested", new JsonObject()
+          .put("{non.existent.placeholder}", "someValue")
+          .put("{another.non.existent.placeholder}", "someOtherValue"));
+  private static final JsonObject JSON_NONEXISTENT_VALUE_PLACEHOLDERS = new JsonObject()
+      .put("api-key", "^mJHG3%#r6@")
+      .put("nested", new JsonObject()
+          .put("ElementA", "{non.existent.placeholder}")
+          .put("ElementB", "{another.non.existent.placeholder}"));
+  private static final JsonObject JSON_NONEXISTENT_VALUE_PLACEHOLDERS_FILLED = new JsonObject()
+      .put("api-key", "^mJHG3%#r6@")
+      .put("nested", new JsonObject()
+          .put("ElementA", "")
+          .put("ElementB", ""));
+
+  private EndpointPlaceholdersResolver tested;
+
+  @Test
+  @DisplayName("Expect unchanged plaintext when no placeholders present and none provided")
+  void plainTextNoPlaceholders() {
+    givenResolverFor(emptyFragmentContext());
+
+    String result = tested.resolve(STRING_NO_PLACEHOLDERS);
+
+    assertEquals(STRING_NO_PLACEHOLDERS, result);
+  }
+
+  @Test
+  @DisplayName("Expect empty strings for placeholders not present in FragmentContext")
+  void placeholdersNotProvided() {
+    givenResolverFor(emptyFragmentContext());
+
+    String result = tested.resolve(STRING_WITH_PLACEHOLDERS);
+
+    assertEquals(STRING_EMPTIED_PLACEHOLDERS, result);
+  }
+
+  @Test
+  @DisplayName("Expect provided placeholders to be filled")
+  void providedPlaceholdersFilled() {
+    givenResolverFor(fragmentContextWithSomeData());
+
+    String result = tested.resolve(STRING_WITH_PLACEHOLDERS);
+
+    assertEquals(STRING_SOME_PLACEHOLDERS_FILLED_OTHER_EMPTIED, result);
+  }
+
+  @Test
+  @DisplayName("Expect unescaped value to be interpolated from Fragment's payload")
+  void singlePlaceholderForPayload() {
+    givenResolverFor(fragmentContextWithApiKey());
+
+    String result = tested.resolve(PAYLOAD_API_KEY_PLACEHOLDER);
+
+    assertEquals(API_KEY, result);
+  }
+
+  @Test
+  @DisplayName("Expect value to be interpolated and escaped from Fragment's payload")
+  void singleEscapedPlaceholderForPayload() {
+    givenResolverFor(fragmentContextWithApiKey());
+
+    String result = tested.resolveAndEncode(PAYLOAD_API_KEY_PLACEHOLDER);
+
+    assertEquals(ENCODED_API_KEY, result);
+  }
+
+  @Test
+  @DisplayName("Expect empty JSON to be passed as-is")
+  void jsonEmptyLeftAsIs() {
+    givenResolverFor(emptyFragmentContext());
+
+    JsonObject result = tested.resolve(new JsonObject());
+
+    assertEquals(new JsonObject(), result);
+  }
+
+  @Test
+  @DisplayName("Expect JSON without placeholders to be passed as-is")
+  void jsonWithoutPlaceholdersLeftAsIs() {
+    givenResolverFor(emptyFragmentContext());
+
+    JsonObject result = tested.resolve(JSON_NO_PLACEHOLDERS);
+
+    assertEquals(JSON_NO_PLACEHOLDERS, result);
+  }
+
+  @Test
+  @DisplayName("Expect unescaped value in JSON to be interpolated from Fragment's payload")
+  void jsonSinglePlaceholderForPayload() {
+    givenResolverFor(fragmentContextWithApiKey());
+
+    JsonObject result = tested.resolve(JSON_SINGLE_PLACEHOLDER);
+
+    assertEquals(JSON_SINGLE_PLACEHOLDER_FILLED, result);
+  }
+
+  @Test
+  @DisplayName("Expect placeholders in JSON to be filled")
+  void jsonWithPlaceholdersFilled() {
+    givenResolverFor(fragmentContextWithSomeData());
+
+    JsonObject result = tested.resolve(JSON_WITH_PLACEHOLDERS);
+
+    assertEquals(JSON_WITH_FILLED_PLACEHOLDERS, result);
+  }
+
+  @Test
+  @DisplayName("Expect non existent placeholders in JSON values to be replaced with empty string")
+  void jsonWithNonExistentPlaceholdersInValuesReplacedWithEmptyString() {
+    givenResolverFor(fragmentContextWithSomeData());
+
+    JsonObject result = tested.resolve(JSON_NONEXISTENT_VALUE_PLACEHOLDERS);
+
+    assertEquals(JSON_NONEXISTENT_VALUE_PLACEHOLDERS_FILLED, result);
+  }
+
+  @Test
+  @DisplayName("Expect interpolating a JSON key to an empty string results in an exception")
+  void jsonEmptyKeyInterpolationFails() {
+    givenResolverFor(emptyFragmentContext());
+
+    assertThrows(IllegalStateException.class, () -> tested.resolve(
+        JSON_NONEXISTENT_KEY_PLACEHOLDERS));
+  }
+
+  private void givenResolverFor(FragmentContext fragmentContext) {
+    tested = new EndpointPlaceholdersResolver(fragmentContext);
+  }
+
+  private FragmentContext emptyFragmentContext() {
+    return new FragmentContext(
+        new Fragment("snippet", new JsonObject(), StringUtils.EMPTY),
+        new ClientRequest()
+    );
+  }
+
+  private FragmentContext fragmentContextWithSomeData() {
+    return new FragmentContext(
+        new Fragment("snippet", new JsonObject(), StringUtils.EMPTY)
+            .appendPayload("httpCall", new JsonObject()
+                .put("_request", new JsonObject().put("source", HTTP_REQUEST_SOURCE))),
+        new ClientRequest().setHeaders(MultiMap.caseInsensitiveMultiMap()
+            .add("Host", HOST_HEADER))
+            .setParams(MultiMap.caseInsensitiveMultiMap().add("refinedQuery", REFINED_QUERY_PARAM))
+    );
+  }
+
+  private FragmentContext fragmentContextWithApiKey() {
+    return new FragmentContext(
+        new Fragment("snippet", new JsonObject(), StringUtils.EMPTY)
+            .appendPayload("api-key", API_KEY),
+        new ClientRequest()
+    );
+  }
+
+}

--- a/handler/actions/src/test/java/io/knotx/fragments/handler/action/http/request/EndpointRequestComposerTest.java
+++ b/handler/actions/src/test/java/io/knotx/fragments/handler/action/http/request/EndpointRequestComposerTest.java
@@ -1,0 +1,277 @@
+/*
+ * Copyright (C) 2019 Knot.x Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.knotx.fragments.handler.action.http.request;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import io.knotx.fragments.api.Fragment;
+import io.knotx.fragments.api.FragmentContext;
+import io.knotx.fragments.handler.action.http.options.EndpointOptions;
+import io.knotx.server.api.context.ClientRequest;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpHeaderValues;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.reactivex.core.MultiMap;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class EndpointRequestComposerTest {
+
+  private static final String INTERPOLATED_VALUE = "interpolated-value";
+  private static final String SAMPLE_BODY_STRING = "sample-body";
+  private static final String SAMPLE_BODY_STRING_WITH_PLACEHOLDER = "{payload.action._result}";
+  private static final JsonObject SAMPLE_BODY_JSON = new JsonObject()
+      .put("key", "value")
+      .put("otherKey", new JsonObject().put("nestedKey", "nestedValue"));
+  private static final JsonObject SAMPLE_BODY_JSON_WITH_PLACEHOLDER = new JsonObject()
+      .put("key", "value")
+      .put("otherKey", new JsonObject().put("nestedKey", "{payload.action._result}"));
+  private static final JsonObject SAMPLE_BODY_JSON_INTERPOLATED = new JsonObject()
+      .put("key", "value")
+      .put("otherKey", new JsonObject().put("nestedKey", INTERPOLATED_VALUE));
+  private static final JsonObject SAMPLE_PAYLOAD = new JsonObject().put("action", new JsonObject().put("_result", INTERPOLATED_VALUE));
+
+  private EndpointRequestComposer tested;
+
+  @Test
+  @DisplayName("Expect extra header when bodyJson specified and Content-Type header not specified")
+  void shouldContainExtraContentTypeHeader() {
+    JsonObject configuration = new JsonObject()
+        .put("path", "/home")
+        .put("domain", "google.com")
+        .put("port", 80)
+        .put("bodyJson", SAMPLE_BODY_JSON);
+
+    givenComposer(configuration);
+
+    EndpointRequest result = tested.createEndpointRequest(sampleFragmentContext());
+
+    assertEquals(HttpHeaderValues.APPLICATION_JSON.toString(),
+        result.getHeaders().get(HttpHeaderNames.CONTENT_TYPE));
+  }
+
+  @Test
+  @DisplayName("Expect unchanged header when bodyJson specified and Content-Type header taken from ClientRequest")
+  void shouldContainUnchangedContentTypeHeaderFromClientRequest() {
+    JsonObject configuration = new JsonObject()
+        .put("path", "/home")
+        .put("domain", "google.com")
+        .put("port", 80)
+        .put("bodyJson", SAMPLE_BODY_JSON)
+        .put("allowedRequestHeaders", new JsonArray().add(HttpHeaderNames.CONTENT_TYPE.toString()));
+
+    givenComposer(configuration);
+
+    EndpointRequest result = tested
+        .createEndpointRequest(sampleFragmentContext(HttpHeaderValues.TEXT_PLAIN.toString()));
+
+    assertEquals(HttpHeaderValues.TEXT_PLAIN.toString(),
+        result.getHeaders().get(HttpHeaderNames.CONTENT_TYPE));
+  }
+
+  @Test
+  @DisplayName("Expect unchanged header when bodyJson specified and Content-Type header specified in configuration")
+  void shouldContainUnchangedContentTypeHeaderFromConfiguration() {
+    JsonObject configuration = new JsonObject()
+        .put("path", "/home")
+        .put("domain", "google.com")
+        .put("port", 80)
+        .put("bodyJson", SAMPLE_BODY_JSON)
+        .put("additionalHeaders", new JsonObject()
+            .put(HttpHeaderNames.CONTENT_TYPE.toString(), HttpHeaderValues.TEXT_PLAIN));
+
+    givenComposer(configuration);
+
+    EndpointRequest result = tested.createEndpointRequest(sampleFragmentContext());
+
+    assertEquals(HttpHeaderValues.TEXT_PLAIN.toString(),
+        result.getHeaders().get(HttpHeaderNames.CONTENT_TYPE));
+  }
+
+  @Test
+  @DisplayName("Expect body as string when provided in configuration")
+  void shouldContainBodyString() {
+    JsonObject configuration = new JsonObject()
+        .put("path", "/home")
+        .put("domain", "google.com")
+        .put("port", 80)
+        .put("body", SAMPLE_BODY_STRING);
+
+    givenComposer(configuration);
+
+    EndpointRequest result = tested.createEndpointRequest(sampleFragmentContext());
+
+    assertEquals(SAMPLE_BODY_STRING, result.getBody());
+  }
+
+  @Test
+  @DisplayName("Expect body as json when provided in configuration")
+  void shouldContainBodyJson() {
+    JsonObject configuration = new JsonObject()
+        .put("path", "/home")
+        .put("domain", "google.com")
+        .put("port", 80)
+        .put("bodyJson", SAMPLE_BODY_JSON);
+
+    givenComposer(configuration);
+
+    EndpointRequest result = tested.createEndpointRequest(sampleFragmentContext());
+
+    assertEquals(SAMPLE_BODY_JSON.toString(), result.getBody());
+  }
+
+  @Test
+  @DisplayName("Expect exception when both body and bodyJson specified")
+  void shouldThrowWhenBothBodyOptionsSpecified() {
+    JsonObject configuration = new JsonObject()
+        .put("path", "/home")
+        .put("domain", "google.com")
+        .put("port", 80)
+        .put("body", SAMPLE_BODY_STRING)
+        .put("bodyJson", SAMPLE_BODY_JSON);
+
+    EndpointOptions options = new EndpointOptions(configuration);
+
+    assertThrows(IllegalArgumentException.class, () -> new EndpointRequestComposer(options));
+  }
+
+  @Test
+  @DisplayName("Expect that body is left as-is when body interpolation is disabled by default")
+  void shouldNotReplacePlaceholdersInBodyByDefault() {
+    JsonObject configuration = new JsonObject()
+        .put("path", "/home")
+        .put("domain", "google.com")
+        .put("port", 80)
+        .put("body", SAMPLE_BODY_STRING_WITH_PLACEHOLDER);
+
+    givenComposer(configuration);
+
+    EndpointRequest result = tested.createEndpointRequest(sampleFragmentContext());
+
+    assertEquals(SAMPLE_BODY_STRING_WITH_PLACEHOLDER, result.getBody());
+  }
+
+  @Test
+  @DisplayName("Expect interpolate body when body interpolation is enabled")
+  void shouldReplacePlaceholdersInBodyWhenFlagSet() {
+    JsonObject configuration = new JsonObject()
+        .put("path", "/home")
+        .put("domain", "google.com")
+        .put("port", 80)
+        .put("body", SAMPLE_BODY_STRING_WITH_PLACEHOLDER)
+        .put("interpolateBody", true);
+
+    givenComposer(configuration);
+
+    EndpointRequest result = tested.createEndpointRequest(sampleFragmentContext(SAMPLE_PAYLOAD));
+
+    assertEquals(INTERPOLATED_VALUE, result.getBody());
+  }
+
+  @Test
+  @DisplayName("Expect that body JSON is left as-is when body interpolation is disabled")
+  void shouldNotReplacePlaceholdersInBodyJsonWhenInterpolationDisabled() {
+    JsonObject configuration = new JsonObject()
+        .put("path", "/home")
+        .put("domain", "google.com")
+        .put("port", 80)
+        .put("bodyJson", SAMPLE_BODY_JSON_WITH_PLACEHOLDER)
+        .put("interpolateBody", false);
+
+    givenComposer(configuration);
+
+    EndpointRequest result = tested.createEndpointRequest(sampleFragmentContext(SAMPLE_PAYLOAD));
+
+    assertEquals(SAMPLE_BODY_JSON_WITH_PLACEHOLDER.toString(), result.getBody());
+  }
+
+  @Test
+  @DisplayName("Expect interpolated JSON body when body interpolation is enabled")
+  void shouldReplacePlaceholdersInJsonBodyWhenFlagSet() {
+    JsonObject configuration = new JsonObject()
+        .put("path", "/home")
+        .put("domain", "google.com")
+        .put("port", 80)
+        .put("bodyJson", SAMPLE_BODY_JSON_WITH_PLACEHOLDER)
+        .put("interpolateBody", true);
+
+    givenComposer(configuration);
+
+    EndpointRequest result = tested.createEndpointRequest(sampleFragmentContext(SAMPLE_PAYLOAD));
+
+    assertEquals(SAMPLE_BODY_JSON_INTERPOLATED.toString(), result.getBody());
+  }
+
+  @Test
+  @DisplayName("Expect interpolated path by default")
+  void shouldInterpolatePathByDefault() {
+    JsonObject configuration = new JsonObject()
+        .put("path", "/home/{payload.action._result}")
+        .put("domain", "google.com")
+        .put("port", 80);
+
+    givenComposer(configuration);
+
+    EndpointRequest result = tested.createEndpointRequest(sampleFragmentContext(SAMPLE_PAYLOAD));
+
+    assertEquals("/home/" + INTERPOLATED_VALUE, result.getPath());
+  }
+
+  @Test
+  @DisplayName("Expect path left as-is when path interpolation disabled")
+  void shouldNotInterpolatePathWhenDisabled() {
+    JsonObject configuration = new JsonObject()
+        .put("path", "/home/{payload.action._result}")
+        .put("domain", "google.com")
+        .put("port", 80)
+        .put("interpolatePath", false);
+
+    givenComposer(configuration);
+
+    EndpointRequest result = tested.createEndpointRequest(sampleFragmentContext(SAMPLE_PAYLOAD));
+
+    assertEquals("/home/{payload.action._result}", result.getPath());
+  }
+
+  private void givenComposer(JsonObject configuration) {
+    tested = new EndpointRequestComposer(new EndpointOptions(configuration));
+  }
+
+  private FragmentContext sampleFragmentContext() {
+    return new FragmentContext(
+        new Fragment("snippet", new JsonObject(), ""),
+        new ClientRequest()
+    );
+  }
+
+  private FragmentContext sampleFragmentContext(JsonObject payload) {
+    return new FragmentContext(
+        new Fragment("snippet", new JsonObject(), "").mergeInPayload(payload),
+        new ClientRequest()
+    );
+  }
+
+  private FragmentContext sampleFragmentContext(String contentType) {
+    return new FragmentContext(
+        new Fragment("snippet", new JsonObject(), ""),
+        new ClientRequest().setHeaders(
+            MultiMap.caseInsensitiveMultiMap().add(HttpHeaderNames.CONTENT_TYPE, contentType))
+    );
+  }
+
+}

--- a/handler/api/src/main/java/io/knotx/fragments/handler/api/exception/ConfigurationException.java
+++ b/handler/api/src/main/java/io/knotx/fragments/handler/api/exception/ConfigurationException.java
@@ -20,4 +20,8 @@ public class ConfigurationException extends RuntimeException {
   public ConfigurationException(String message) {
     super(message);
   }
+
+  public ConfigurationException(String message, Throwable cause) {
+    super(message, cause);
+  }
 }


### PR DESCRIPTION
Support for new HTTP methods. Composing body for PUT/POST/PATCH methods using String/JSON format with optional interpolation (disabled by default). Applying `application/json` Content-Type header when sending Json body.

Fix for processing WebClientOptions of HttpActionOptions - not generated in converter previously due to a non-public setter modifier.

## Motivation and Context
#73 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](/CONTRIBUTING.md#coding-conventions) of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

---
I hereby agree to the terms of the Knot.x Contributor License Agreement.
