### PR TITLE
#133 EndpointInvoker integration tests documenting current behaviour.

### DIFF
--- a/actions/core/README.md
+++ b/actions/core/README.md
@@ -143,7 +143,7 @@ This is specified using `httpMethod` option under `config` node of HttpAction (d
 
 For `POST`, `PUT` and `PATCH` methods, request body is sent. 
 Body can be specified either as String or as a JSON, using `body` and `bodyJson` parameters under `endpointOptions`.
-It is possible to perform interpolation using values from  original request, Fragment's configuration or Fragment's payload.
+It is possible to perform interpolation using values from the original request, Fragment's configuration or Fragment's payload.
 For details, see [Knot.x Server Common Placeholders](https://github.com/Knotx/knotx-server-http/tree/master/common/placeholders#available-request-placeholders-support).
 Please note that unlike for path, placeholders in body will not be URL-encoded.
  
@@ -151,13 +151,13 @@ To enable body interpolation, set `interpolateBody` flag under `endpointOptions`
 
 #### Encoding
 
-Currently only placeholders in path are URL-encoded. Any other value is passed as-is, i.e.:
+Currently, only placeholders in a path are URL-encoded. Any other value is passed as-is, i.e.:
 - path schema
 - body schema + resolved placeholders
 - custom header
 - client's header allowed to be passed on
 
-Therefore, all configuration-based values (path schema, body schema, headers) **must** be encoded in configuration.
+Therefore, all configuration-based values (path schema, body schema, headers) **must** be encoded in the configuration.
 
 Values used for path interpolation **must not** be encoded (otherwise a double encoding might occur).
 

--- a/actions/core/README.md
+++ b/actions/core/README.md
@@ -141,13 +141,27 @@ The table below presents expected entries in node log on particular log levels d
 Currently Knot.x supports `GET`, `POST`, `PUT`, `PATCH`, `DELETE` and `HEAD` HTTP methods.
 This is specified using `httpMethod` option under `config` node of HttpAction (defaults to `GET`).
 
-For `POST`, `PUT` and `PATCH` methods, request body is send. 
+For `POST`, `PUT` and `PATCH` methods, request body is sent. 
 Body can be specified either as String or as a JSON, using `body` and `bodyJson` parameters under `endpointOptions`.
-In both cases, it is possible to perform interpolation based on the original request, Fragment's configuration or Fragment's payload.
+It is possible to perform interpolation using values from  original request, Fragment's configuration or Fragment's payload.
 For details, see [Knot.x Server Common Placeholders](https://github.com/Knotx/knotx-server-http/tree/master/common/placeholders#available-request-placeholders-support).
-Please note that unlike for path, placeholder values put into body are not URL-encoded.
+Please note that unlike for path, placeholders in body will not be URL-encoded.
  
 To enable body interpolation, set `interpolateBody` flag under `endpointOptions` to `true`.
+
+#### Encoding
+
+Currently only placeholders in path are URL-encoded. Any other value is passed as-is, i.e.:
+- path schema
+- body schema + resolved placeholders
+- custom header
+- client's header allowed to be passed on
+
+Therefore, all configuration-based values (path schema, body schema, headers) **must** be encoded in configuration.
+
+Values used for path interpolation **must not** be encoded (otherwise a double encoding might occur).
+
+Client request's values used for interpolation are already in a raw form (when decoded by Knot.x HTTP Server).
 
 #### Detailed configuration
 All configuration options are explained in details in the [Config Options Cheetsheet](https://github.com/Knotx/knotx-fragments/tree/master/handler/core/docs/asciidoc/dataobjects.adoc).

--- a/actions/core/README.md
+++ b/actions/core/README.md
@@ -133,8 +133,11 @@ The table below presents expected entries in node log on particular log levels d
 | `_success`                                 | ERROR      |                                            |
 | exception occurs and `_error`              | INFO       | REQUEST_DATA, LIST_OF_ERRORS               |
 | exception occurs and `_error`              | ERROR      | REQUEST_DATA, LIST_OF_ERRORS               |
-| `_error` (e.g service responds with `500`) | INFO       | REQUEST_DATA, RESPONSE_DATA, RESPONSE_BODY |
-| `_error` (e.g service responds with `500`) | INFO       | REQUEST_DATA, RESPONSE_DATA                |
+| `_error` (e.g service responds with `500`) | INFO       | REQUEST_DATA, RESPONSE_DATA, RESPONSE_BODY, LIST_OF_ERRORS |
+| `_error` (e.g service responds with `500`) | ERROR       | REQUEST_DATA, RESPONSE_DATA, LIST_OF_ERRORS                |
+| request composition fails and `_error`     | INFO, ERROR | LIST_OF_ERRORS                |
+
+The HTTP Action always calls the handler with a succeeded future. The future always has a `_success` or an `_error` transition and contains a node log. 
 
 #### Supported HTTP methods
 

--- a/actions/core/src/test/java/io/knotx/fragments/action/http/EndpointInvokerIntegrationTest.java
+++ b/actions/core/src/test/java/io/knotx/fragments/action/http/EndpointInvokerIntegrationTest.java
@@ -1,0 +1,191 @@
+package io.knotx.fragments.action.http;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import io.knotx.fragments.action.http.options.EndpointOptions;
+import io.knotx.fragments.action.http.options.HttpActionOptions;
+import io.knotx.fragments.action.http.request.EndpointRequest;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+import io.vertx.reactivex.core.MultiMap;
+import io.vertx.reactivex.ext.web.client.WebClient;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+@ExtendWith(VertxExtension.class)
+class EndpointInvokerIntegrationTest {
+
+  private static Stream<Arguments> headersWithSpecialCharsInValues() {
+    return Stream.of( // headerName, headerValue
+        Arguments.of("Content", "param: value1; param: value2_*(24&1)"),
+        Arguments.of("Content", new JsonObject()
+            .put("param", "value")
+            .put("ids", new JsonArray().add(1).add(2).add(3))
+            .toString()
+        )
+    );
+  }
+
+  private static Stream<Arguments> headersWithIllegalCharsInNames() {
+    return Stream.of( // headerName, headerValue
+        Arguments.of("Content Type", "param: value;"),
+        Arguments.of("Content:Type", "param: value;"),
+        Arguments.of("Content\nType", "param: value;"),
+        Arguments.of("Content;Type", "param: value;")
+    );
+  }
+
+  private WireMockServer server;
+
+  @BeforeEach
+  void setUp() {
+    server = new WireMockServer(WireMockConfiguration.options().dynamicPort());
+    server.start();
+  }
+
+  @AfterEach
+  void tearDown() {
+    server.stop();
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {
+      "/api/products?fq_style=\"Hats, Scarves & Gloves\"&fq_attr=\"Size^8\"",
+      "/test test/",
+      "/some&%%/path"
+  })
+  @DisplayName("Expect 400 Bad Request response for path that is not encoded by EndpointInvoker")
+  void shouldNotEncodePath(String path, Vertx vertx, VertxTestContext testContext)
+      throws InterruptedException {
+    // given
+    EndpointRequest endpointRequest = new EndpointRequest(path, MultiMap.caseInsensitiveMultiMap());
+    configureServer(path);
+    WebClient webClient = WebClient.create(io.vertx.reactivex.core.Vertx.newInstance(vertx));
+
+    EndpointInvoker tested = new EndpointInvoker(webClient, createOptions());
+
+    // when, then
+    tested.invokeEndpoint(endpointRequest).subscribe(
+        response -> {
+          testContext.verify(() -> assertEquals(400, response.statusCode()));
+          testContext.completeNow();
+        },
+        testContext::failNow
+    );
+    assertTrue(testContext.awaitCompletion(60, TimeUnit.SECONDS));
+  }
+
+  @ParameterizedTest
+  @MethodSource("headersWithSpecialCharsInValues")
+  @DisplayName("Expect 200 response for headers values that are not encoded by EndpointInvoker")
+  void shouldAcceptNotEncodedHeaderValues(String headerName, String headerValue, Vertx vertx,
+      VertxTestContext testContext)
+      throws InterruptedException {
+    // given
+    MultiMap headers = MultiMap.caseInsensitiveMultiMap().add(headerName, headerValue);
+
+    EndpointRequest endpointRequest = new EndpointRequest("/", headers);
+    WebClient webClient = WebClient.create(io.vertx.reactivex.core.Vertx.newInstance(vertx));
+    configureServer(headerName, headerValue);
+
+    EndpointInvoker tested = new EndpointInvoker(webClient, createOptions());
+
+    // when, then
+    tested.invokeEndpoint(endpointRequest).subscribe(
+        response -> {
+          testContext.verify(() -> assertEquals(200, response.statusCode()));
+          testContext.completeNow();
+        },
+        testContext::failNow
+    );
+    assertTrue(testContext.awaitCompletion(60, TimeUnit.SECONDS));
+  }
+
+  @ParameterizedTest
+  @MethodSource("headersWithIllegalCharsInNames")
+  @DisplayName("Expect exception raised by WebClient when header name is illegal")
+  void shouldNotAllowIllegalHeaders(String headerName, String headerValue, Vertx vertx,
+      VertxTestContext testContext) throws InterruptedException {
+    // given
+    MultiMap headers = MultiMap.caseInsensitiveMultiMap().add(headerName, headerValue);
+
+    EndpointRequest endpointRequest = new EndpointRequest("/", headers);
+    WebClient webClient = WebClient.create(io.vertx.reactivex.core.Vertx.newInstance(vertx));
+
+    EndpointInvoker tested = new EndpointInvoker(webClient, createOptions());
+
+    // when, then
+    tested.invokeEndpoint(endpointRequest).subscribe(
+        response -> testContext.failNow(new IllegalStateException(String
+            .format("Exception not thrown for parameters [%s] [%s]", headerName, headerValue))),
+        error -> {
+          assertEquals(IllegalArgumentException.class, error.getClass());
+          testContext.completeNow();
+        }
+    );
+    assertTrue(testContext.awaitCompletion(60, TimeUnit.SECONDS));
+  }
+
+  @Test
+  @DisplayName("Expect WebClient to ignore header with empty name, but WireMockServer expecting it")
+  void shouldIgnoreEmptyHeaderButServerExpects(Vertx vertx, VertxTestContext testContext)
+      throws InterruptedException {
+    // given
+    MultiMap headers = MultiMap.caseInsensitiveMultiMap().add(StringUtils.EMPTY, "some-value");
+    configureServer(StringUtils.EMPTY, "some-value");
+
+    EndpointRequest endpointRequest = new EndpointRequest("/", headers);
+    WebClient webClient = WebClient.create(io.vertx.reactivex.core.Vertx.newInstance(vertx));
+
+    EndpointInvoker tested = new EndpointInvoker(webClient, createOptions());
+
+    // when, then
+    tested.invokeEndpoint(endpointRequest).subscribe(
+        response -> {
+          testContext.verify(() -> assertEquals(404, response.statusCode()));
+          testContext.completeNow();
+        },
+        testContext::failNow
+    );
+    assertTrue(testContext.awaitCompletion(60, TimeUnit.SECONDS));
+  }
+
+  private void configureServer(String path) {
+    server.stubFor(get(urlEqualTo(path)).willReturn(aResponse().withStatus(200)));
+  }
+
+  private void configureServer(String headerName, String headerValue) {
+    server.stubFor(get(urlEqualTo("/")).withHeader(headerName, equalTo(headerValue))
+        .willReturn(aResponse().withStatus(200)));
+  }
+
+  private HttpActionOptions createOptions() {
+    EndpointOptions options = new EndpointOptions()
+        .setDomain("localhost")
+        .setPort(server.port());
+
+    return new HttpActionOptions()
+        .setEndpointOptions(options);
+  }
+
+}

--- a/actions/core/src/test/java/io/knotx/fragments/action/http/EndpointInvokerTest.java
+++ b/actions/core/src/test/java/io/knotx/fragments/action/http/EndpointInvokerTest.java
@@ -119,7 +119,8 @@ class EndpointInvokerTest {
     when(request.putHeaders(any())).thenReturn(request);
 
     lenient().when(request.rxSend()).thenReturn(Single.just(response));
-    lenient().when(request.rxSendBuffer(Buffer.buffer(expectedBody))).thenReturn(Single.just(response));
+    lenient().when(request.rxSendBuffer(Buffer.buffer(expectedBody)))
+        .thenReturn(Single.just(response));
   }
 
 }


### PR DESCRIPTION
Intergration tests describing current behaviour of EndpointInvoker, WebClient & WireMockServer interoperability.

There is no path/parameter/header encoding performed by EndpointInvoker or Vert.x WebClient currently. WebClient has some validation for header names though.

## Description
#133 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the [code style](/CONTRIBUTING.md#coding-conventions) of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---
I hereby agree to the terms of the Knot.x Contributor License Agreement.
