### PR TITLE
Add missing licence header

### DIFF
--- a/actions/core/src/test/java/io/knotx/fragments/action/http/EndpointInvokerIntegrationTest.java
+++ b/actions/core/src/test/java/io/knotx/fragments/action/http/EndpointInvokerIntegrationTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2019 Knot.x Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.knotx.fragments.action.http;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;


### PR DESCRIPTION
Provides missing licence header. File causing RAT exception was introduced in #137 