### PR TITLE
#168 Extends  event log with node error details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to `knotx-fragments` will be documented in this file.
 
 ## Unreleased
 List of changes that are finished but not yet released in any final version.
+- [PR-172](https://github.com/Knotx/knotx-stack/pull/172) - Add a task node processing exception to event log. Remove unused 'TIMEOUT' node status. Update node unit tests.
 - [PR-170](https://github.com/Knotx/knotx-stack/pull/170) - Upgrade to Vert.x `3.9.1`, replace deprecated `setHandler` with `onComplete`.
                 
 ## 2.2.1

--- a/task/api/src/main/java/io/knotx/fragments/task/api/NodeFatalException.java
+++ b/task/api/src/main/java/io/knotx/fragments/task/api/NodeFatalException.java
@@ -12,23 +12,24 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * The code comes from https://github.com/tomaszmichalak/vertx-rx-map-reduce.
  */
-package io.knotx.fragments.task.engine.exception;
+package io.knotx.fragments.task.api;
 
-import io.knotx.fragments.api.Fragment;
-
+/**
+ * This exception informs that task processing can not be continued.
+ */
 public class NodeFatalException extends IllegalStateException {
 
-  private Fragment fragment;
-
-  public NodeFatalException(Fragment fragment) {
-    super("Failed during fragment processing [" + fragment.getId() + "]");
-    this.fragment = fragment;
+  public NodeFatalException(String message) {
+    super(message);
   }
 
-  public Fragment getFragment() {
-    return fragment;
+  public NodeFatalException(Throwable cause) {
+    super(cause);
   }
+
+  public NodeFatalException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
 }

--- a/task/engine/README.md
+++ b/task/engine/README.md
@@ -95,14 +95,14 @@ then a fragment status is `failure`.<br/>
 
 #### Fragment log
 A fragment's log contains details about task processing. When node processing ends (or
-raises an exception), the engine appends the new [entry](https://github.com/Knotx/knotx-fragments/blob/master/engine/src/main/java/io/knotx/fragments/engine/EventLogEntry.java)
-in the fragment's log containing:
-- task name
-- node identifier
-- node status
-- [node log](https://github.com/Knotx/knotx-fragments/tree/master/task/api##node-log)
-- transition
-- timestamp.
+raises an exception), the engine appends the new entry in the fragment's log containing:
+- task name (`String`)
+- node identifier (`String`)
+- node status (`io.knotx.fragments.task.engine.EventLogEntry.NodeStatus`)
+- transition (`String`)
+- node log (`io.vertx.core.json.JsonObject`)
+- error (`Throwable`)
+- timestamp (`Long`).
 
 Node status is a simple text value managed by the engine. It resembles a fragment's status but is a
 bit more accurate (such as a `UNSUPPORTED_TRANSITION` value).
@@ -115,7 +115,17 @@ task is a graph of two nodes: `A` and `B`.
 The `A` node responds with the `_success` transition. Then the `B` node starts processing and responds
 with the `_succcess` transition. Finally, the fragment status is `SUCCESS` and the fragment's log contains:
 
-| Task       | Node identifier | Node status | Transition | Node Log        |
-|------------|-----------------|-------------|------------|-----------------|
-| `taskName` | `A`             | SUCCESS     | `_success` | { A node log }  |
-| `taskName` | `B`             | SUCCESS     | `_success` | { B node log }  |
+| Timestamp | Task       | Node identifier | Node status | Transition | Node Log        |  Error  |
+|-----------|------------|-----------------|-------------|------------|-----------------| ------- |
+| 1111111111| `taskName` | `A`             | UNPROCESSED |            |                 |         |
+| 1111111112| `taskName` | `A`             | SUCCESS     | `_success` | { A node log }  |         |
+| 1111111113| `taskName` | `B`             | UNPROCESSED |            |                 |         |
+| 1111111114| `taskName` | `B`             | SUCCESS     | `_success` | { B node log }  |         |
+
+Please note that every time, a leaf node (in a task or subtask) responds with a transition different 
+than `_success` then the engine adds the unsupported transition entry. See the example below:
+
+| Timestamp | Task       | Node identifier | Node status            | Transition | Node Log        |   Error   |
+|-----------|------------|-----------------|------------------------|------------|-----------------| --------- |
+| 1111111111| `taskName` | `B`             | ERROR                  | `_error`   | { }             | Throwable |
+| 1111111112| `taskName` | `B`             | UNSUPPORTED_TRANSITION | `_error`   | { }             | Throwable |

--- a/task/engine/src/main/java/io/knotx/fragments/task/engine/EventLog.java
+++ b/task/engine/src/main/java/io/knotx/fragments/task/engine/EventLog.java
@@ -15,16 +15,11 @@
  */
 package io.knotx.fragments.task.engine;
 
-import io.vertx.core.json.JsonArray;
-import io.vertx.core.json.JsonObject;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 public class EventLog {
-
-  private static final String OPERATIONS_KEY = "operations";
 
   private final List<EventLogEntry> operations;
 
@@ -32,18 +27,8 @@ public class EventLog {
     operations = new ArrayList<>();
   }
 
-  public EventLog(JsonObject json) {
-    operations = json.getJsonArray(OPERATIONS_KEY).stream()
-        .map(JsonObject.class::cast)
-        .map(EventLogEntry::new)
-        .collect(Collectors.toList());
-  }
-
-  public JsonObject toJson() {
-    final JsonArray jsonArray = new JsonArray();
-    operations.forEach(entry -> jsonArray.add(entry.toJson()));
-    return new JsonObject()
-        .put(OPERATIONS_KEY, jsonArray);
+  public EventLog(List<EventLogEntry> operations) {
+    this.operations = operations;
   }
 
   void append(EventLogEntry logEntry) {
@@ -70,10 +55,6 @@ public class EventLog {
         .mapToLong(EventLogEntry::getTimestamp)
         .max()
         .orElse(0);
-  }
-
-  public JsonObject getLog() {
-    return toJson();
   }
 
   @Override

--- a/task/engine/src/main/java/io/knotx/fragments/task/engine/FragmentEvent.java
+++ b/task/engine/src/main/java/io/knotx/fragments/task/engine/FragmentEvent.java
@@ -20,17 +20,10 @@ import static io.knotx.fragments.api.FragmentResult.ERROR_TRANSITION;
 import static io.knotx.fragments.api.FragmentResult.SUCCESS_TRANSITION;
 
 import io.knotx.fragments.api.Fragment;
-import io.vertx.codegen.annotations.DataObject;
-import io.vertx.core.json.JsonObject;
 import java.util.Objects;
 import java.util.Optional;
 
-@DataObject
 public class FragmentEvent {
-
-  private static final String FRAGMENT_KEY = "fragment";
-  private static final String LOG_KEY = "log";
-  private static final String STATUS_KEY = "status";
 
   private final EventLog log;
   private Fragment fragment;
@@ -40,19 +33,6 @@ public class FragmentEvent {
     this.fragment = fragment;
     this.log = new EventLog();
     this.status = Status.UNPROCESSED;
-  }
-
-  public FragmentEvent(JsonObject json) {
-    this.fragment = new Fragment(json.getJsonObject(FRAGMENT_KEY));
-    this.log = new EventLog(json.getJsonObject(LOG_KEY));
-    this.status = Status.valueOf(json.getString(STATUS_KEY));
-  }
-
-  public JsonObject toJson() {
-    return new JsonObject()
-        .put(FRAGMENT_KEY, fragment.toJson())
-        .put(LOG_KEY, log.toJson())
-        .put(STATUS_KEY, status);
   }
 
   public FragmentEvent log(EventLogEntry logEntry) {
@@ -67,10 +47,6 @@ public class FragmentEvent {
   public FragmentEvent setFragment(Fragment fragment) {
     this.fragment = fragment;
     return this;
-  }
-
-  public JsonObject getLogAsJson() {
-    return log.toJson();
   }
 
   public EventLog getLog() {

--- a/task/engine/src/main/java/io/knotx/fragments/task/engine/FragmentEventContext.java
+++ b/task/engine/src/main/java/io/knotx/fragments/task/engine/FragmentEventContext.java
@@ -16,15 +16,9 @@
 package io.knotx.fragments.task.engine;
 
 import io.knotx.server.api.context.ClientRequest;
-import io.vertx.codegen.annotations.DataObject;
-import io.vertx.core.json.JsonObject;
 import java.util.Objects;
 
-@DataObject
 public class FragmentEventContext {
-
-  private static final String FRAGMENT_EVENT_KEY = "fragmentEvent";
-  private static final String CLIENT_REQUEST_KEY = "clientRequest";
 
   private final FragmentEvent fragmentEvent;
   private final ClientRequest clientRequest;
@@ -32,17 +26,6 @@ public class FragmentEventContext {
   public FragmentEventContext(FragmentEvent fragmentEvent, ClientRequest clientRequest) {
     this.fragmentEvent = fragmentEvent;
     this.clientRequest = clientRequest;
-  }
-
-  public FragmentEventContext(JsonObject json) {
-    this.fragmentEvent = new FragmentEvent(json.getJsonObject(FRAGMENT_EVENT_KEY));
-    this.clientRequest = new ClientRequest(json.getJsonObject(CLIENT_REQUEST_KEY));
-  }
-
-  public JsonObject toJson() {
-    return new JsonObject()
-        .put(FRAGMENT_EVENT_KEY, fragmentEvent.toJson())
-        .put(CLIENT_REQUEST_KEY, clientRequest.toJson());
   }
 
   public FragmentEvent getFragmentEvent() {

--- a/task/engine/src/main/java/io/knotx/fragments/task/engine/TaskFatalException.java
+++ b/task/engine/src/main/java/io/knotx/fragments/task/engine/TaskFatalException.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2019 Knot.x Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.knotx.fragments.task.engine;
+
+import io.knotx.fragments.task.api.NodeFatalException;
+
+/**
+ * When {@link TaskEngine} processes a fragment and executes a task, then when a node responds with
+ * {@link NodeFatalException} then this exception is propagated to providing more context details.
+ * Both exceptions are propagated via {@link io.reactivex.exceptions.CompositeException}.
+ */
+public class TaskFatalException extends IllegalStateException {
+
+  private final FragmentEventContext context;
+
+  TaskFatalException(FragmentEventContext context) {
+    this.context = context;
+  }
+
+  /**
+   * Fragment event context. Please note that for a composite node, this context does not cover
+   * other subtasks.
+   *
+   * @return event context
+   */
+  public FragmentEventContext getContext() {
+    return context;
+  }
+}

--- a/task/engine/src/test/java/io/knotx/fragments/task/engine/FragmentEventLogVerifierTest.java
+++ b/task/engine/src/test/java/io/knotx/fragments/task/engine/FragmentEventLogVerifierTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright (C) 2019 Knot.x Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.knotx.fragments.task.engine;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.knotx.fragments.task.engine.FragmentEventLogVerifier.Operation;
+import io.vertx.core.json.JsonObject;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class FragmentEventLogVerifierTest {
+
+  @Test
+  @DisplayName("Expect verify all with no error when empty.")
+  void expectVerifyAllNoErrorWhenEmpty() {
+    List<EventLogEntry> operations = Collections.emptyList();
+    FragmentEventLogVerifier.verifyAllLogEntries(operations);
+  }
+
+  @Test
+  @DisplayName("Expect verify all with no error when the same.")
+  void expectVerifyAllNoErrorWhenTheSame() {
+    List<EventLogEntry> operations =
+        Collections.singletonList(EventLogEntry.error("task", "a", "_error"));
+    FragmentEventLogVerifier
+        .verifyAllLogEntries(operations, Operation.exact("task", "a", "ERROR", 0));
+  }
+
+  @Test
+  @DisplayName("Expect verify all with error when not same.")
+  void expectVerifyAllErrorWhenNotSame() {
+    List<EventLogEntry> operations =
+        Collections.singletonList(EventLogEntry.error("task", "b", "_error", new JsonObject()));
+    assertThrows(AssertionError.class, () -> FragmentEventLogVerifier
+        .verifyAllLogEntries(operations, Operation.exact("task", "a", "ERROR", 0)));
+  }
+
+  @Test
+  @DisplayName("Expect verify all with error when invalid position.")
+  void expectVerifyAllErrorWhenInvalidPosition() {
+    List<EventLogEntry> operations =
+        Collections.singletonList(EventLogEntry.error("task", "b", "_error", new JsonObject()));
+    assertThrows(AssertionError.class, () -> FragmentEventLogVerifier
+        .verifyAllLogEntries(operations, Operation.exact("task", "a", "ERROR", 1)));
+  }
+
+  @Test
+  @DisplayName("Expect verify all with error when elements count not same.")
+  void expectVerifyAllErrorWhenSizeDiffers() {
+    List<EventLogEntry> operations =
+        Arrays.asList(
+            EventLogEntry.error("task", "a", "_error", new JsonObject()),
+            EventLogEntry.error("task", "b", "_error", new JsonObject()));
+    assertThrows(AssertionError.class, () -> FragmentEventLogVerifier
+        .verifyAllLogEntries(operations, Operation.exact("task", "a", "ERROR", 0)));
+  }
+
+  @Test
+  @DisplayName("Expect verify with no error when empty.")
+  void expectVerifyNoErrorWhenEmpty() {
+    List<EventLogEntry> operations = Collections.emptyList();
+    FragmentEventLogVerifier.verifyLogEntries(operations);
+  }
+
+  @Test
+  @DisplayName("Expect verify with no error when the same.")
+  void expectVerifyNoErrorWhenTheSame() {
+    List<EventLogEntry> operations =
+        Collections.singletonList(EventLogEntry.error("task", "a", "_error", new JsonObject()));
+    FragmentEventLogVerifier
+        .verifyLogEntries(operations, Operation.exact("task", "a", "ERROR", 0));
+  }
+
+  @Test
+  @DisplayName("Expect verify with error when not same.")
+  void expectVerifyErrorWhenNotSame() {
+    List<EventLogEntry> operations =
+        Collections.singletonList(EventLogEntry.error("task", "b", "_error", new JsonObject()));
+    assertThrows(AssertionError.class, () -> FragmentEventLogVerifier
+        .verifyLogEntries(operations, Operation.exact("task", "a", "ERROR", 0)));
+  }
+
+  @Test
+  @DisplayName("Expect verify with error when invalid position.")
+  void expectVerifyErrorWhenInvalidPosition() {
+    List<EventLogEntry> operations =
+        Collections.singletonList(EventLogEntry.error("task", "b", "_error", new JsonObject()));
+    assertThrows(AssertionError.class, () -> FragmentEventLogVerifier
+        .verifyLogEntries(operations, Operation.exact("task", "a", "ERROR", 1)));
+  }
+
+  @Test
+  @DisplayName("Expect verify when elements count not same.")
+  void expectVerifyNoErrorWhenSizeDiffers() {
+    List<EventLogEntry> operations =
+        Arrays.asList(
+            EventLogEntry.error("task", "a", "_error", new JsonObject()),
+            EventLogEntry.error("task", "b", "_error", new JsonObject()));
+    FragmentEventLogVerifier
+        .verifyLogEntries(operations, Operation.exact("task", "a", "ERROR", 0));
+  }
+
+  @Test
+  @DisplayName("Expect verify when elements in range.")
+  void expectVerifyNoErrorWhenInRange() {
+    List<EventLogEntry> operations =
+        Arrays.asList(
+            EventLogEntry.error("task", "a", "_error", new JsonObject()),
+            EventLogEntry.error("task", "b", "_error", new JsonObject()));
+    FragmentEventLogVerifier
+        .verifyLogEntries(operations, Operation.range("task", "a", "ERROR", 0, 1));
+  }
+
+  @Test
+  @DisplayName("Expect verify when elements in range.")
+  void expectVerifyErrorWhenNotInRange() {
+    List<EventLogEntry> operations =
+        Arrays.asList(
+            EventLogEntry.error("task", "a", "_error", new JsonObject()),
+            EventLogEntry.error("task", "b", "_error", new JsonObject()));
+    assertThrows(AssertionError.class, () -> FragmentEventLogVerifier
+        .verifyLogEntries(operations, Operation.range("task", "a", "ERROR", 1, 2)));
+  }
+}

--- a/task/engine/src/test/java/io/knotx/fragments/task/engine/FragmentsEngineOrderTest.java
+++ b/task/engine/src/test/java/io/knotx/fragments/task/engine/FragmentsEngineOrderTest.java
@@ -15,17 +15,18 @@
  */
 package io.knotx.fragments.task.engine;
 
-import static io.knotx.fragments.task.engine.Nodes.single;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.knotx.fragments.api.Fragment;
 import io.knotx.fragments.api.FragmentOperation;
-import io.knotx.fragments.task.api.Task;
-import io.knotx.fragments.task.api.Node;
 import io.knotx.fragments.api.FragmentResult;
+import io.knotx.fragments.task.api.Node;
+import io.knotx.fragments.task.api.Task;
+import io.knotx.junit5.util.RequestUtil;
 import io.knotx.server.api.context.ClientRequest;
 import io.reactivex.Single;
+import io.reactivex.functions.Consumer;
 import io.vertx.core.Future;
 import io.vertx.core.json.JsonObject;
 import io.vertx.junit5.VertxExtension;
@@ -34,7 +35,6 @@ import io.vertx.reactivex.core.Vertx;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Consumer;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -91,16 +91,10 @@ class FragmentsEngineOrderTest {
   void verifyExecution(Single<List<FragmentEvent>> result,
       Consumer<List<FragmentEvent>> successConsumer,
       VertxTestContext testContext) throws Throwable {
-    result.subscribe(
-        onSuccess -> testContext.verify(() -> {
-          successConsumer.accept(onSuccess);
-          testContext.completeNow();
-        }), testContext::failNow);
-
+    RequestUtil.subscribeToResult_shouldSucceed(testContext, result, successConsumer);
     assertTrue(testContext.awaitCompletion(5, TimeUnit.SECONDS));
     if (testContext.failed()) {
       throw testContext.causeOfFailure();
     }
   }
-
 }

--- a/task/engine/src/test/java/io/knotx/fragments/task/engine/TestFunction.java
+++ b/task/engine/src/test/java/io/knotx/fragments/task/engine/TestFunction.java
@@ -21,7 +21,7 @@ import static io.knotx.fragments.api.FragmentResult.SUCCESS_TRANSITION;
 import io.knotx.fragments.api.Fragment;
 import io.knotx.fragments.api.FragmentOperation;
 import io.knotx.fragments.api.FragmentResult;
-import io.knotx.fragments.task.engine.exception.NodeFatalException;
+import io.knotx.fragments.task.api.NodeFatalException;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
@@ -52,6 +52,14 @@ interface TestFunction extends FragmentOperation {
     };
   }
 
+  static TestFunction error() {
+    return (fragmentContext, resultHandler) -> {
+      Fragment fragment = fragmentContext.getFragment();
+      FragmentResult result = new FragmentResult(fragment, ERROR_TRANSITION);
+      Future.succeededFuture(result).onComplete(resultHandler);
+    };
+  }
+
   static TestFunction errorWithNodeLog(JsonObject nodeLog) {
     return (fragmentContext, resultHandler) -> {
       Fragment fragment = fragmentContext.getFragment();
@@ -66,9 +74,13 @@ interface TestFunction extends FragmentOperation {
         new RuntimeException()).onComplete(resultHandler);
   }
 
-  static TestFunction fatal(Fragment fragment) {
-    return (fragmentContext, resultHandler) -> Future.<FragmentResult>failedFuture(
-        new NodeFatalException(fragment))
+  static TestFunction failure(Throwable error) {
+    return (fragmentContext, resultHandler) -> Future.<FragmentResult>failedFuture(error)
+        .onComplete(resultHandler);
+  }
+
+  static TestFunction fatal(NodeFatalException fatalException) {
+    return (fragmentContext, resultHandler) -> Future.<FragmentResult>failedFuture(fatalException)
         .onComplete(resultHandler);
   }
 

--- a/task/engine/src/test/java/io/knotx/fragments/task/engine/Transitions.java
+++ b/task/engine/src/test/java/io/knotx/fragments/task/engine/Transitions.java
@@ -32,4 +32,8 @@ public interface Transitions {
     return Collections.singletonMap(ERROR_TRANSITION, node);
   }
 
+  static Map<String, Node> on(String transition, Node node) {
+    return Collections.singletonMap(transition, node);
+  }
+
 }

--- a/task/handler/core/src/main/java/io/knotx/fragments/task/handler/consumer/EventLogConverter.java
+++ b/task/handler/core/src/main/java/io/knotx/fragments/task/handler/consumer/EventLogConverter.java
@@ -77,7 +77,7 @@ class EventLogConverter {
     final LoggedNodeStatus result;
     if (SUCCESS_TRANSITION.equals(transition)) {
       result = LoggedNodeStatus.SUCCESS;
-    } else if (ERROR_TRANSITION.equals(transition) || status == NodeStatus.TIMEOUT) {
+    } else if (ERROR_TRANSITION.equals(transition)) {
       result = LoggedNodeStatus.ERROR;
     } else if (StringUtils.isNotEmpty(transition) && status != NodeStatus.UNSUPPORTED_TRANSITION) {
       result = LoggedNodeStatus.OTHER;

--- a/task/handler/core/src/test/java/io/knotx/fragments/task/handler/consumer/MetadataConverterTest.java
+++ b/task/handler/core/src/test/java/io/knotx/fragments/task/handler/consumer/MetadataConverterTest.java
@@ -22,10 +22,10 @@ import static io.knotx.junit5.assertions.KnotxAssertions.assertJsonEquals;
 import com.google.common.collect.ImmutableMap;
 import io.knotx.fragments.api.Fragment;
 import io.knotx.fragments.api.FragmentResult;
+import io.knotx.fragments.task.api.NodeType;
 import io.knotx.fragments.task.engine.EventLog;
 import io.knotx.fragments.task.engine.EventLogEntry;
 import io.knotx.fragments.task.engine.FragmentEvent;
-import io.knotx.fragments.task.api.NodeType;
 import io.knotx.fragments.task.factory.api.metadata.NodeMetadata;
 import io.knotx.fragments.task.factory.api.metadata.OperationMetadata;
 import io.knotx.fragments.task.factory.api.metadata.TaskMetadata;
@@ -37,7 +37,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.stream.Collectors;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -139,7 +138,7 @@ class MetadataConverterTest {
             .put(ERROR_TRANSITION, jsonForMissingNode(missingNodeId)))
         .put("response", new JsonObject()
             .put("transition", ERROR_TRANSITION)
-            .put("invocations", new JsonArray()));
+            .put("invocations", new JsonArray().add(new JsonObject())));
 
     assertJsonEquals(expected, output);
   }
@@ -311,7 +310,7 @@ class MetadataConverterTest {
             .put(SUCCESS_TRANSITION, jsonForNode("b-composite", "subtasks")
                 .put("response", new JsonObject()
                     .put("transition", ERROR_TRANSITION)
-                    .put("invocations", new JsonArray()))
+                    .put("invocations", new JsonArray().add(new JsonObject())))
                 .put("status", LoggedNodeStatus.ERROR)
                 .put("type", NodeType.COMPOSITE)
                 .put("label", "composite")
@@ -345,9 +344,7 @@ class MetadataConverterTest {
   }
 
   private EventLog createEventLog(EventLogEntry... entries) {
-    return new EventLog(new JsonObject()
-        .put("operations", new JsonArray(
-            Arrays.stream(entries).map(EventLogEntry::toJson).collect(Collectors.toList()))));
+    return new EventLog(Arrays.asList(entries));
   }
 
   private FragmentResult createFragmentResult(String transition, JsonObject nodeLog) {


### PR DESCRIPTION
<!-- Please update the sections below that apply, remove the rest -->

## Description
Relates to #168. Extends a task processing event log with error details.

## Motivation and Context
In this PR we prepare to propagate error details to the execution log.

## Upgrade notes (if appropriate)
- Move `io.knotx.fragments.task.engine.exception.NodeFatalException` (from Task Engine module) with `io.knotx.fragments.task.api.NodeFatalException` (to Task API module). When a node throws an exception, the task engine handles it and responds with `io.reactivex.exceptions.CompositeException` containing both `NodeFatalException` and `io.knotx.fragments.task.engine.TaskFatalException`.
- Remove 'TIMEOUT' from `NodeStatus`. Task engine does not support any time restriction on nodes. It is node responsibility to add such "behaviours". See [Actions](https://github.com/Knotx/knotx-fragments/tree/master/action/library) for more details.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/Knotx/knotx/blob/master/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---
I hereby agree to the terms of the Knot.x Contributor License Agreement.
