### PR TITLE
#168 Add errors to the task execution log.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to `knotx-fragments` will be documented in this file.
 
 ## Unreleased
 List of changes that are finished but not yet released in any final version.
+- [PR-174](https://github.com/Knotx/knotx-stack/pull/172) - Add node processing errors to the [graph node response log](https://github.com/Knotx/knotx-fragments/blob/master/task/handler/log/api/docs/asciidoc/dataobjects.adoc#graphnoderesponselog).
 - [PR-172](https://github.com/Knotx/knotx-stack/pull/172) - Add a task node processing exception to event log. Remove unused 'TIMEOUT' node status. Update node unit tests.
 - [PR-170](https://github.com/Knotx/knotx-stack/pull/170) - Upgrade to Vert.x `3.9.1`, replace deprecated `setHandler` with `onComplete`.
                 

--- a/task/handler/core/src/main/java/io/knotx/fragments/task/handler/consumer/EventLogConverter.java
+++ b/task/handler/core/src/main/java/io/knotx/fragments/task/handler/consumer/EventLogConverter.java
@@ -21,8 +21,10 @@ import static io.knotx.fragments.api.FragmentResult.SUCCESS_TRANSITION;
 import io.knotx.fragments.task.engine.EventLogEntry;
 import io.knotx.fragments.task.engine.EventLogEntry.NodeStatus;
 import io.knotx.fragments.task.handler.log.api.model.LoggedNodeStatus;
+import io.reactivex.exceptions.CompositeException;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
+import java.util.Collections;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.List;
@@ -43,7 +45,7 @@ class EventLogConverter {
 
     NodeExecutionData result = new NodeExecutionData(getLoggedNodesStatus(logs));
     if (transition != null) {
-      result.setResponse(transition, inJsonArray(getNodeLog(logs)));
+      result.setResponse(transition, getNodeLog(logs), getErrors(logs));
     }
 
     result.setStarted(getStartTimestamp(logs));
@@ -93,10 +95,17 @@ class EventLogConverter {
         .orElse(null);
   }
 
+  private List<Throwable> getErrors(List<EventLogEntry> logs) {
+    return getErrorsForExecution(logs)
+        .map(EventLogEntry::getError)
+        .map(EventLogConverter::flat)
+        .orElse(Collections.emptyList());
+  }
+
   private JsonObject getNodeLog(List<EventLogEntry> logs) {
     return getLogForExecution(logs)
         .map(EventLogEntry::getNodeLog)
-        .orElse(null);
+        .orElse(new JsonObject());
   }
 
   private List<EventLogEntry> getLogEntriesFor(String id) {
@@ -117,16 +126,20 @@ class EventLogConverter {
         .findFirst();
   }
 
+  private Optional<EventLogEntry> getErrorsForExecution(List<EventLogEntry> logs) {
+    return logs.stream()
+        .filter(log -> ERROR_TRANSITION.equals(log.getTransition()))
+        .reduce((previous, current) -> current);
+  }
+
   private boolean hasCorrectTransition(EventLogEntry log) {
     return !NodeStatus.UNSUPPORTED_TRANSITION.equals(log.getStatus());
   }
 
-  private JsonArray inJsonArray(JsonObject instance) {
-    if (instance != null) {
-      return new JsonArray().add(instance);
-    } else {
-      return new JsonArray();
-    }
+  private static List<Throwable> flat(Throwable e) {
+    return e instanceof CompositeException ?
+        ((CompositeException) e).getExceptions() :
+        Collections.singletonList(e);
   }
 
 }

--- a/task/handler/core/src/main/java/io/knotx/fragments/task/handler/consumer/EventLogConverter.java
+++ b/task/handler/core/src/main/java/io/knotx/fragments/task/handler/consumer/EventLogConverter.java
@@ -22,7 +22,6 @@ import io.knotx.fragments.task.engine.EventLogEntry;
 import io.knotx.fragments.task.engine.EventLogEntry.NodeStatus;
 import io.knotx.fragments.task.handler.log.api.model.LoggedNodeStatus;
 import io.reactivex.exceptions.CompositeException;
-import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import java.util.Collections;
 import org.apache.commons.lang3.StringUtils;
@@ -96,7 +95,7 @@ class EventLogConverter {
   }
 
   private List<Throwable> getErrors(List<EventLogEntry> logs) {
-    return getErrorsForExecution(logs)
+    return getLogForExecution(logs)
         .map(EventLogEntry::getError)
         .map(EventLogConverter::flat)
         .orElse(Collections.emptyList());
@@ -116,23 +115,17 @@ class EventLogConverter {
 
   private Optional<EventLogEntry> getLogForExecution(List<EventLogEntry> logs) {
     return logs.stream()
-        .filter(this::hasCorrectTransition)
+        .filter(this::skipUnsupportedEntries)
         .reduce((previous, current) -> current);
   }
 
   private Optional<EventLogEntry> getLogForStart(List<EventLogEntry> logs) {
     return logs.stream()
-        .filter(this::hasCorrectTransition)
+        .filter(this::skipUnsupportedEntries)
         .findFirst();
   }
 
-  private Optional<EventLogEntry> getErrorsForExecution(List<EventLogEntry> logs) {
-    return logs.stream()
-        .filter(log -> ERROR_TRANSITION.equals(log.getTransition()))
-        .reduce((previous, current) -> current);
-  }
-
-  private boolean hasCorrectTransition(EventLogEntry log) {
+  private boolean skipUnsupportedEntries(EventLogEntry log) {
     return !NodeStatus.UNSUPPORTED_TRANSITION.equals(log.getStatus());
   }
 

--- a/task/handler/core/src/main/java/io/knotx/fragments/task/handler/consumer/MetadataConverter.java
+++ b/task/handler/core/src/main/java/io/knotx/fragments/task/handler/consumer/MetadataConverter.java
@@ -69,7 +69,7 @@ class MetadataConverter {
     if (metadataResponse != null) {
       graphLog
           .setResponse(GraphNodeResponseLog.newInstance(metadataResponse.getTransition(),
-              metadataResponse.getInvocations()));
+              metadataResponse.getLog()));
     }
   }
 

--- a/task/handler/core/src/main/java/io/knotx/fragments/task/handler/consumer/NodeExecutionData.java
+++ b/task/handler/core/src/main/java/io/knotx/fragments/task/handler/consumer/NodeExecutionData.java
@@ -17,6 +17,8 @@ package io.knotx.fragments.task.handler.consumer;
 
 import io.knotx.fragments.task.handler.log.api.model.LoggedNodeStatus;
 import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import java.util.List;
 
 class NodeExecutionData {
 
@@ -53,26 +55,41 @@ class NodeExecutionData {
     return response;
   }
 
-  void setResponse(String transaction, JsonArray invocations) {
-    this.response = new Response(transaction, invocations);
+  void setResponse(String transaction, JsonObject log, List<Throwable> errors) {
+    this.response = new Response(transaction, log, errors);
   }
 
   static class Response {
 
     private final String transition;
-    private final JsonArray invocations;
+    private final JsonObject log;
+    private final List<Throwable> errors;
 
-    Response(String transition, JsonArray invocations) {
+    Response(String transition, JsonObject log, List<Throwable> errors) {
       this.transition = transition;
-      this.invocations = invocations;
+      this.log = log;
+      this.errors = errors;
     }
 
     String getTransition() {
       return transition;
     }
 
-    JsonArray getInvocations() {
-      return invocations;
+    JsonObject getLog() {
+      return log;
+    }
+
+    List<Throwable> getErrors() {
+      return errors;
+    }
+
+    @Override
+    public String toString() {
+      return "Response{" +
+          "transition='" + transition + '\'' +
+          ", log=" + log +
+          ", errors=" + errors +
+          '}';
     }
   }
 

--- a/task/handler/core/src/test/java/io/knotx/fragments/task/handler/consumer/MetadataConverterTest.java
+++ b/task/handler/core/src/test/java/io/knotx/fragments/task/handler/consumer/MetadataConverterTest.java
@@ -116,8 +116,10 @@ class MetadataConverterTest {
   @Test
   @DisplayName("Expect missing node metadata when transition returned in log that was not described")
   void shouldProduceCorrectJsonForMissingNodeCase() {
+    JsonObject nodeLog = simpleNodeLog();
+
     EventLogEntry[] logs = new EventLogEntry[]{
-        EventLogEntry.error(TASK_NAME, ROOT_NODE, ERROR_TRANSITION),
+        EventLogEntry.error(TASK_NAME, ROOT_NODE, ERROR_TRANSITION, nodeLog),
         EventLogEntry.unsupported(TASK_NAME, ROOT_NODE, ERROR_TRANSITION)
     };
 
@@ -138,7 +140,7 @@ class MetadataConverterTest {
             .put(ERROR_TRANSITION, jsonForMissingNode(missingNodeId)))
         .put("response", new JsonObject()
             .put("transition", ERROR_TRANSITION)
-            .put("invocations", new JsonArray().add(new JsonObject())));
+            .put("log", nodeLog));
 
     assertJsonEquals(expected, output);
   }
@@ -161,7 +163,7 @@ class MetadataConverterTest {
         .put("status", LoggedNodeStatus.SUCCESS)
         .put("response", new JsonObject()
             .put("transition", SUCCESS_TRANSITION)
-            .put("invocations", wrap(simpleNodeLog())));
+            .put("log", simpleNodeLog()));
 
     assertJsonEquals(expected, output);
   }
@@ -303,14 +305,14 @@ class MetadataConverterTest {
     JsonObject expected = jsonForActionNode("a-node")
         .put("response", new JsonObject()
             .put("transition", SUCCESS_TRANSITION)
-            .put("invocations", wrap(simpleNodeLog())))
+            .put("log", simpleNodeLog()))
         .put("status", LoggedNodeStatus.SUCCESS)
         .put("on", new JsonObject()
             .put(ERROR_TRANSITION, jsonForActionNode("c-node"))
             .put(SUCCESS_TRANSITION, jsonForNode("b-composite", "subtasks")
                 .put("response", new JsonObject()
                     .put("transition", ERROR_TRANSITION)
-                    .put("invocations", new JsonArray().add(new JsonObject())))
+                    .put("log", new JsonObject()))
                 .put("status", LoggedNodeStatus.ERROR)
                 .put("type", NodeType.COMPOSITE)
                 .put("label", "composite")
@@ -319,7 +321,7 @@ class MetadataConverterTest {
                     .put(ERROR_TRANSITION, jsonForActionNode("f-node")
                         .put("response", new JsonObject()
                             .put("transition", SUCCESS_TRANSITION)
-                            .put("invocations", wrap(simpleNodeLog())))
+                            .put("log", simpleNodeLog()))
                         .put("status", LoggedNodeStatus.SUCCESS)
                     )
                 )
@@ -327,7 +329,7 @@ class MetadataConverterTest {
                     jsonForActionNode("b1-subgraph")
                         .put("response", new JsonObject()
                             .put("transition", SUCCESS_TRANSITION)
-                            .put("invocations", wrap(simpleNodeLog())))
+                            .put("log", simpleNodeLog()))
                         .put("status", LoggedNodeStatus.SUCCESS),
                     jsonForActionNode("b2-subgraph")
                         .put("on", new JsonObject()
@@ -335,7 +337,7 @@ class MetadataConverterTest {
                             .put("_fallback", jsonForMissingNode(missingNodeId)))
                         .put("response", new JsonObject()
                             .put("transition", "_fallback")
-                            .put("invocations", wrap(complexNodeLog())))
+                            .put("log", complexNodeLog()))
                         .put("status", LoggedNodeStatus.OTHER)
                 )))
             ));

--- a/task/handler/core/src/test/java/io/knotx/fragments/task/handler/consumer/MetadataConverterTest.java
+++ b/task/handler/core/src/test/java/io/knotx/fragments/task/handler/consumer/MetadataConverterTest.java
@@ -31,6 +31,7 @@ import io.knotx.fragments.task.factory.api.metadata.OperationMetadata;
 import io.knotx.fragments.task.factory.api.metadata.TaskMetadata;
 import io.knotx.fragments.task.handler.log.api.model.GraphNodeOperationLog;
 import io.knotx.fragments.task.handler.log.api.model.LoggedNodeStatus;
+import io.reactivex.exceptions.CompositeException;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import java.util.Arrays;
@@ -75,7 +76,7 @@ class MetadataConverterTest {
   @Test
   @DisplayName("Expect correct JSON when metadata with one node provided")
   void shouldProduceCorrectJsonForOneNodeMetadata() {
-    givenNodesMetadata(ROOT_NODE, simpleNode(ROOT_NODE, "custom"));
+    givenNodesMetadata(ROOT_NODE, singleNode(ROOT_NODE, "custom"));
 
     JsonObject output = tested.getExecutionLog().toJson();
 
@@ -87,7 +88,7 @@ class MetadataConverterTest {
   @Test
   @DisplayName("Expect correct JSON when metadata with one action node provided")
   void shouldProduceCorrectJsonForOneActionNodeMetadata() {
-    givenNodesMetadata(ROOT_NODE, simpleNode(ROOT_NODE, "action"));
+    givenNodesMetadata(ROOT_NODE, singleNode(ROOT_NODE, "action"));
 
     JsonObject output = tested.getExecutionLog().toJson();
 
@@ -100,8 +101,8 @@ class MetadataConverterTest {
   @DisplayName("Expect correct JSON when metadata with two nodes with transition provided")
   void shouldProduceCorrectJsonForTwoNodesWithTransition() {
     givenNodesMetadata(ROOT_NODE,
-        simpleNode(ROOT_NODE, "custom", ImmutableMap.of(SUCCESS_TRANSITION, "node-A")),
-        simpleNode("node-A", "factory-A")
+        singleNode(ROOT_NODE, "custom", ImmutableMap.of(SUCCESS_TRANSITION, "node-A")),
+        singleNode("node-A", "factory-A")
     );
 
     JsonObject output = tested.getExecutionLog().toJson();
@@ -114,18 +115,19 @@ class MetadataConverterTest {
   }
 
   @Test
-  @DisplayName("Expect missing node metadata when transition returned in log that was not described")
+  @DisplayName("Expect missing node metadata when node ends with _error transition.")
   void shouldProduceCorrectJsonForMissingNodeCase() {
     JsonObject nodeLog = simpleNodeLog();
 
     EventLogEntry[] logs = new EventLogEntry[]{
+        // d
         EventLogEntry.error(TASK_NAME, ROOT_NODE, ERROR_TRANSITION, nodeLog),
         EventLogEntry.unsupported(TASK_NAME, ROOT_NODE, ERROR_TRANSITION)
     };
 
     givenEventLogAndNodesMetadata(createEventLog(logs), ROOT_NODE,
-        simpleNode(ROOT_NODE, "custom", ImmutableMap.of(SUCCESS_TRANSITION, "node-A")),
-        simpleNode("node-A", "factory-A")
+        singleNode(ROOT_NODE, "custom", ImmutableMap.of(SUCCESS_TRANSITION, "node-A")),
+        singleNode("node-A", "factory-A")
     );
 
     JsonObject output = tested.getExecutionLog().toJson();
@@ -154,7 +156,7 @@ class MetadataConverterTest {
     };
 
     givenEventLogAndNodesMetadata(createEventLog(logs), ROOT_NODE,
-        simpleNode(ROOT_NODE, "custom")
+        singleNode(ROOT_NODE, "custom")
     );
 
     JsonObject output = tested.getExecutionLog().toJson();
@@ -169,13 +171,48 @@ class MetadataConverterTest {
   }
 
   @Test
+  @DisplayName("Expect errors in response when node throws an exception.")
+  void shouldProduceCorrectJsonForExceptionFromNode() {
+    CompositeException error = compositeError();
+
+    EventLogEntry[] logs = new EventLogEntry[]{
+        EventLogEntry.exception(TASK_NAME, ROOT_NODE, ERROR_TRANSITION, error),
+        EventLogEntry.unsupported(TASK_NAME, ROOT_NODE, ERROR_TRANSITION)
+    };
+
+    givenEventLogAndNodesMetadata(createEventLog(logs), ROOT_NODE,
+        singleNode(ROOT_NODE, "custom", ImmutableMap.of("custom", "node-A")),
+        singleNode("node-A", "factory-A")
+    );
+
+    JsonObject output = tested.getExecutionLog().toJson();
+
+    JsonObject expected = jsonForNode(ROOT_NODE, "custom")
+        .put("status", LoggedNodeStatus.ERROR)
+        .put("on", new JsonObject()
+            .put("custom", jsonForNode("node-A", "factory-A")))
+        .put("response", new JsonObject()
+            .put("transition", ERROR_TRANSITION)
+            .put("log", new JsonObject())
+            .put("errors", new JsonArray().add(
+                new JsonObject().put("className", "java.lang.IllegalArgumentException")
+                    .put("message", "error message 1")).add(
+                new JsonObject().put("className", "java.lang.IllegalStateException")
+                    .put("message", "error message 2"))
+            ));
+
+    assertJsonEquals(expected, output);
+  }
+
+
+  @Test
   @DisplayName("Expect correct JSON when metadata with nested nodes provided")
   void shouldProduceCorrectJsonForCompositeNodeWithSimpleNodes() {
     givenNodesMetadata(ROOT_NODE,
         compositeNode(ROOT_NODE, "custom", "node-A", "node-B", "node-C"),
-        simpleNode("node-A", "factory-A"),
-        simpleNode("node-B", "factory-B"),
-        simpleNode("node-C", "factory-C")
+        singleNode("node-A", "factory-A"),
+        singleNode("node-B", "factory-B"),
+        singleNode("node-C", "factory-C")
     );
 
     JsonObject output = tested.getExecutionLog().toJson();
@@ -197,9 +234,9 @@ class MetadataConverterTest {
   void shouldProduceCorrectJsonForCompositeNodeWithSimpleNodesNotAllDescribed() {
     givenNodesMetadata(ROOT_NODE,
         compositeNode(ROOT_NODE, "custom", "node-A", "node-B", "node-C"),
-        simpleNode("node-A", "factory-A"),
-        simpleNode("node-B", "factory-B"),
-        simpleNode("node-C", "factory-C")
+        singleNode("node-A", "factory-A"),
+        singleNode("node-B", "factory-B"),
+        singleNode("node-C", "factory-C")
     );
 
     JsonObject output = tested.getExecutionLog().toJson();
@@ -220,21 +257,21 @@ class MetadataConverterTest {
   @DisplayName("Expect correct JSON when full metadata for complex graph provided")
   void shouldProduceCorrectJsonForComplexGraphWithFullMetadata() {
     givenNodesMetadata(ROOT_NODE,
-        simpleNode(ROOT_NODE, "custom",
+        singleNode(ROOT_NODE, "custom",
             ImmutableMap.of(SUCCESS_TRANSITION, "node-A", "_failure", "node-B")),
-        simpleNode("node-A", "factory-A"),
+        singleNode("node-A", "factory-A"),
         compositeSubtasksNode("node-B",
             ImmutableMap
                 .of(SUCCESS_TRANSITION, "node-C", ERROR_TRANSITION, "node-D", "_timeout", "node-E"),
             "node-B1", "node-B2", "node-B3"
         ),
-        simpleNode("node-B1", "action", ImmutableMap.of(SUCCESS_TRANSITION, "node-B1-special")),
-        simpleNode("node-B1-special", "factory-B1-special"),
-        simpleNode("node-B2", "factory-B2"),
-        simpleNode("node-B3", "factory-B3"),
-        simpleNode("node-C", "factory-C"),
-        simpleNode("node-D", "factory-D"),
-        simpleNode("node-E", "factory-E")
+        singleNode("node-B1", "action", ImmutableMap.of(SUCCESS_TRANSITION, "node-B1-special")),
+        singleNode("node-B1-special", "factory-B1-special"),
+        singleNode("node-B2", "factory-B2"),
+        singleNode("node-B3", "factory-B3"),
+        singleNode("node-C", "factory-C"),
+        singleNode("node-D", "factory-D"),
+        singleNode("node-E", "factory-E")
     );
 
     JsonObject output = tested.getExecutionLog().toJson();
@@ -282,18 +319,18 @@ class MetadataConverterTest {
     givenEventLogAndNodesMetadata(
         eventLog,
         "a-node",
-        simpleNode("a-node", "action",
+        singleNode("a-node", "action",
             ImmutableMap.of(SUCCESS_TRANSITION, "b-composite", ERROR_TRANSITION, "c-node")),
         compositeSubtasksNode("b-composite",
             ImmutableMap.of(SUCCESS_TRANSITION, "e-node", ERROR_TRANSITION, "f-node"),
             "b1-subgraph", "b2-subgraph"
         ),
-        simpleNode("b1-subgraph", "action"),
-        simpleNode("b2-subgraph", "action", ImmutableMap.of(SUCCESS_TRANSITION, "d-node")),
-        simpleNode("c-node", "action"),
-        simpleNode("d-node", "action"),
-        simpleNode("e-node", "action"),
-        simpleNode("f-node", "action")
+        singleNode("b1-subgraph", "action"),
+        singleNode("b2-subgraph", "action", ImmutableMap.of(SUCCESS_TRANSITION, "d-node")),
+        singleNode("c-node", "action"),
+        singleNode("d-node", "action"),
+        singleNode("e-node", "action"),
+        singleNode("f-node", "action")
     );
 
     JsonObject output = tested.getExecutionLog().toJson();
@@ -387,20 +424,20 @@ class MetadataConverterTest {
     return output;
   }
 
-  private NodeMetadata simpleNode(String id, String factory) {
-    return simpleNode(id, factory, ImmutableMap.of());
+  private NodeMetadata singleNode(String id, String factory) {
+    return singleNode(id, factory, ImmutableMap.of());
   }
 
-  private NodeMetadata simpleNode(String id, String factory, Map<String, String> transitions) {
+  private NodeMetadata singleNode(String id, String factory, Map<String, String> transitions) {
     return NodeMetadata.single(
         id,
         "simple",
         transitions,
-        getSampleConfigFor(factory)
+        operationMetadata(factory)
     );
   }
 
-  private OperationMetadata getSampleConfigFor(String factory) {
+  private OperationMetadata operationMetadata(String factory) {
     final OperationMetadata result;
     if ("action".equals(factory)) {
       result = new OperationMetadata(factory, new JsonObject().put("actionFactory", "http"));
@@ -426,7 +463,7 @@ class MetadataConverterTest {
         "composite",
         transitions,
         Arrays.asList(nested),
-        getSampleConfigFor(factory)
+        operationMetadata(factory)
     );
   }
 
@@ -510,5 +547,11 @@ class MetadataConverterTest {
                         .put("statusCode", 500)))
         )
         ));
+  }
+
+  private CompositeException compositeError() {
+    return new CompositeException(
+        new IllegalArgumentException("error message 1"),
+        new IllegalStateException("error message 2"));
   }
 }

--- a/task/handler/log/api/docs/asciidoc/dataobjects.adoc
+++ b/task/handler/log/api/docs/asciidoc/dataobjects.adoc
@@ -30,6 +30,19 @@ Possible values: <code>UNPROCESSED</code>, <code>SUCCESS</code> and <code>FAILUR
 +++
 |===
 
+[[GraphNodeErrorLog]]
+== GraphNodeErrorLog
+
+
+[cols=">25%,25%,50%"]
+[frame="topbot"]
+|===
+^|Name | Type ^| Description
+|[[className]]`@className`|`String`|-
+|[[message]]`@message`|`String`|-
+|[[stacktrace]]`@stacktrace`|`Json array`|-
+|===
+
 [[GraphNodeExecutionLog]]
 == GraphNodeExecutionLog
 
@@ -112,8 +125,9 @@ Node factory name.
 [frame="topbot"]
 |===
 ^|Name | Type ^| Description
-|[[invocations]]`@invocations`|`Json array`|+++
-List of node invocation(s) logs.
+|[[errors]]`@errors`|`Array of link:dataobjects.html#GraphNodeErrorLog[GraphNodeErrorLog]`|-
+|[[log]]`@log`|`Json object`|+++
+Node response log.
 +++
 |[[transition]]`@transition`|`String`|+++
 Node response transition.

--- a/task/handler/log/api/src/main/java/io/knotx/fragments/task/handler/log/api/model/GraphNodeErrorLog.java
+++ b/task/handler/log/api/src/main/java/io/knotx/fragments/task/handler/log/api/model/GraphNodeErrorLog.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2019 Knot.x Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.knotx.fragments.task.handler.log.api.model;
+
+import io.vertx.codegen.annotations.DataObject;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import java.util.Objects;
+
+@DataObject(generateConverter = true)
+public class GraphNodeErrorLog {
+
+  private String className;
+  private String message;
+  private JsonArray stacktrace;
+
+  public GraphNodeErrorLog() {
+    // default constructor
+  }
+
+  public GraphNodeErrorLog(JsonObject json) {
+    GraphNodeErrorLogConverter.fromJson(json, this);
+  }
+
+  public JsonObject toJson() {
+    JsonObject result = new JsonObject();
+    GraphNodeErrorLogConverter.toJson(this, result);
+    return result;
+  }
+
+  public String getClassName() {
+    return className;
+  }
+
+  public GraphNodeErrorLog setClassName(String className) {
+    this.className = className;
+    return this;
+  }
+
+  public String getMessage() {
+    return message;
+  }
+
+  public GraphNodeErrorLog setMessage(String message) {
+    this.message = message;
+    return this;
+  }
+
+  public JsonArray getStacktrace() {
+    return stacktrace;
+  }
+
+  public GraphNodeErrorLog setStacktrace(JsonArray stacktrace) {
+    this.stacktrace = stacktrace;
+    return this;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    GraphNodeErrorLog that = (GraphNodeErrorLog) o;
+    return Objects.equals(className, that.className) &&
+        Objects.equals(message, that.message) &&
+        Objects.equals(stacktrace, that.stacktrace);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(className, message, stacktrace);
+  }
+
+  @Override
+  public String toString() {
+    return "GraphNodeErrorLog{" +
+        "className='" + className + '\'' +
+        ", message='" + message + '\'' +
+        ", stacktrace=" + stacktrace +
+        '}';
+  }
+}

--- a/task/handler/log/api/src/main/java/io/knotx/fragments/task/handler/log/api/model/GraphNodeErrorLog.java
+++ b/task/handler/log/api/src/main/java/io/knotx/fragments/task/handler/log/api/model/GraphNodeErrorLog.java
@@ -18,7 +18,9 @@ package io.knotx.fragments.task.handler.log.api.model;
 import io.vertx.codegen.annotations.DataObject;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
+import java.util.Arrays;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 @DataObject(generateConverter = true)
 public class GraphNodeErrorLog {
@@ -29,6 +31,17 @@ public class GraphNodeErrorLog {
 
   public GraphNodeErrorLog() {
     // default constructor
+  }
+
+  public static GraphNodeErrorLog newInstance(Throwable error) {
+    final JsonArray stackTraceLogs = new JsonArray(Arrays.stream(error.getStackTrace())
+        .map(StackTraceElement::toString)
+        .collect(Collectors.toList()));
+
+    return new GraphNodeErrorLog()
+        .setClassName(error.getClass().getCanonicalName())
+        .setMessage(error.getMessage())
+        .setStacktrace(stackTraceLogs);
   }
 
   public GraphNodeErrorLog(JsonObject json) {

--- a/task/handler/log/api/src/main/java/io/knotx/fragments/task/handler/log/api/model/GraphNodeResponseLog.java
+++ b/task/handler/log/api/src/main/java/io/knotx/fragments/task/handler/log/api/model/GraphNodeResponseLog.java
@@ -16,8 +16,8 @@
 package io.knotx.fragments.task.handler.log.api.model;
 
 import io.vertx.codegen.annotations.DataObject;
-import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
+import java.util.List;
 import java.util.Objects;
 
 /**
@@ -27,12 +27,13 @@ import java.util.Objects;
 public class GraphNodeResponseLog {
 
   private String transition;
-  private JsonArray invocations;
+  private JsonObject log;
+  private List<GraphNodeErrorLog> errors;
 
-  public static GraphNodeResponseLog newInstance(String transition, JsonArray invocations) {
+  public static GraphNodeResponseLog newInstance(String transition, JsonObject log) {
     return new GraphNodeResponseLog()
         .setTransition(transition)
-        .setInvocations(invocations);
+        .setLog(log);
   }
 
   public GraphNodeResponseLog() {
@@ -65,16 +66,25 @@ public class GraphNodeResponseLog {
   }
 
   /**
-   * List of node invocation(s) logs.
+   * Node response log.
    *
-   * @return list of node invocation(s) logs
+   * @return node response log
    */
-  public JsonArray getInvocations() {
-    return invocations;
+  public JsonObject getLog() {
+    return log;
   }
 
-  public GraphNodeResponseLog setInvocations(JsonArray invocations) {
-    this.invocations = invocations;
+  public GraphNodeResponseLog setLog(JsonObject log) {
+    this.log = log;
+    return this;
+  }
+
+  public List<GraphNodeErrorLog> getErrors() {
+    return errors;
+  }
+
+  public GraphNodeResponseLog setErrors(List<GraphNodeErrorLog> errors) {
+    this.errors = errors;
     return this;
   }
 
@@ -88,19 +98,21 @@ public class GraphNodeResponseLog {
     }
     GraphNodeResponseLog that = (GraphNodeResponseLog) o;
     return Objects.equals(transition, that.transition) &&
-        Objects.equals(invocations, that.invocations);
+        Objects.equals(log, that.log) &&
+        Objects.equals(errors, that.errors);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(transition, invocations);
+    return Objects.hash(transition, log, errors);
   }
 
   @Override
   public String toString() {
     return "GraphNodeResponseLog{" +
         "transition='" + transition + '\'' +
-        ", invocations=" + invocations +
+        ", log=" + log +
+        ", errors=" + errors +
         '}';
   }
 }

--- a/task/handler/log/api/src/main/java/io/knotx/fragments/task/handler/log/api/model/GraphNodeResponseLog.java
+++ b/task/handler/log/api/src/main/java/io/knotx/fragments/task/handler/log/api/model/GraphNodeResponseLog.java
@@ -17,6 +17,7 @@ package io.knotx.fragments.task.handler.log.api.model;
 
 import io.vertx.codegen.annotations.DataObject;
 import io.vertx.core.json.JsonObject;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
@@ -30,10 +31,12 @@ public class GraphNodeResponseLog {
   private JsonObject log;
   private List<GraphNodeErrorLog> errors;
 
-  public static GraphNodeResponseLog newInstance(String transition, JsonObject log) {
+  public static GraphNodeResponseLog newInstance(String transition, JsonObject log,
+      List<GraphNodeErrorLog> errors) {
     return new GraphNodeResponseLog()
         .setTransition(transition)
-        .setLog(log);
+        .setLog(log)
+        .setErrors(errors);
   }
 
   public GraphNodeResponseLog() {
@@ -75,7 +78,7 @@ public class GraphNodeResponseLog {
   }
 
   public GraphNodeResponseLog setLog(JsonObject log) {
-    this.log = log;
+    this.log = log == null ? new JsonObject() : log;
     return this;
   }
 
@@ -84,7 +87,7 @@ public class GraphNodeResponseLog {
   }
 
   public GraphNodeResponseLog setErrors(List<GraphNodeErrorLog> errors) {
-    this.errors = errors;
+    this.errors = errors == null ? Collections.emptyList() : errors;
     return this;
   }
 

--- a/task/handler/log/api/src/test/java/io/knotx/fragments/task/handler/log/api/model/GraphNodeResponseLogTest.java
+++ b/task/handler/log/api/src/test/java/io/knotx/fragments/task/handler/log/api/model/GraphNodeResponseLogTest.java
@@ -15,29 +15,105 @@
  */
 package io.knotx.fragments.task.handler.log.api.model;
 
+import static io.knotx.fragments.api.FragmentResult.ERROR_TRANSITION;
+import static io.knotx.fragments.api.FragmentResult.SUCCESS_TRANSITION;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import io.knotx.fragments.api.FragmentResult;
 import io.vertx.core.json.JsonObject;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 class GraphNodeResponseLogTest {
 
+  public static final JsonObject SUCCESS_NODE_LOG = new JsonObject().put("debug", "true");
+  public static final List<GraphNodeErrorLog> ERROR_LOG_LIST = Arrays.asList(
+      GraphNodeErrorLog.newInstance(new IllegalArgumentException("some message")),
+      GraphNodeErrorLog.newInstance(new IllegalArgumentException()));
+  public static final JsonObject EMPTY_SUCCESS_NODE_LOG = new JsonObject();
+
   @Test
-  void validateSerialization() {
+  @DisplayName("Expect success transition and node log are serialized correctly.")
+  void expectSuccessNodeResponse() {
     // given
-    String transition = FragmentResult.SUCCESS_TRANSITION;
-
-    JsonObject log = new JsonObject().put("debug", "true");
-
     GraphNodeResponseLog origin = GraphNodeResponseLog
-        .newInstance(transition, log);
+        .newInstance(SUCCESS_TRANSITION, SUCCESS_NODE_LOG, Collections.emptyList());
 
     // when
     GraphNodeResponseLog tested = new GraphNodeResponseLog(origin.toJson());
 
     // then
-    assertEquals(transition, tested.getTransition());
-    assertEquals(log, tested.getLog());
+    assertEquals(SUCCESS_TRANSITION, tested.getTransition());
+    assertEquals(SUCCESS_NODE_LOG, tested.getLog());
+    assertNotNull(tested.getErrors());
+    assertTrue(tested.getErrors().isEmpty());
+  }
+
+  @Test
+  @DisplayName("Expect custom transition and node log are serialized correctly.")
+  void expectSuccessNodeResponseWithCustomTransition() {
+    // given
+    String expectedTransition = "custom";
+    GraphNodeResponseLog origin = GraphNodeResponseLog
+        .newInstance(expectedTransition, SUCCESS_NODE_LOG, Collections.emptyList());
+
+    // when
+    GraphNodeResponseLog tested = new GraphNodeResponseLog(origin.toJson());
+
+    // then
+    assertEquals(expectedTransition, tested.getTransition());
+    assertEquals(SUCCESS_NODE_LOG, tested.getLog());
+    assertNotNull(tested.getErrors());
+    assertTrue(tested.getErrors().isEmpty());
+  }
+
+  @Test
+  @DisplayName("Expect error transition and error logs are serialized correctly.")
+  void expectErrorNodeResponse() {
+    // given
+    GraphNodeResponseLog origin = GraphNodeResponseLog
+        .newInstance(ERROR_TRANSITION, EMPTY_SUCCESS_NODE_LOG, ERROR_LOG_LIST);
+
+    // when
+    GraphNodeResponseLog tested = new GraphNodeResponseLog(origin.toJson());
+
+    // then
+    assertEquals(ERROR_TRANSITION, tested.getTransition());
+    assertEquals(EMPTY_SUCCESS_NODE_LOG, tested.getLog());
+    assertEquals(ERROR_LOG_LIST, tested.getErrors());
+  }
+
+  @Test
+  @DisplayName("Expect empty error log list when null passed.")
+  void expectEmptyErrorsWhenNull() {
+    // given
+    GraphNodeResponseLog origin = GraphNodeResponseLog
+        .newInstance(ERROR_TRANSITION, EMPTY_SUCCESS_NODE_LOG, null);
+
+    // when
+    GraphNodeResponseLog tested = new GraphNodeResponseLog(origin.toJson());
+
+    // then
+    assertNotNull(tested.getErrors());
+    assertTrue(tested.getErrors().isEmpty());
+  }
+
+  @Test
+  @DisplayName("Expect empty error log list when null passed.")
+  void expectEmptyExecutionLogWhenNull() {
+    // given
+    GraphNodeResponseLog origin = GraphNodeResponseLog
+        .newInstance(SUCCESS_TRANSITION, null, Collections.emptyList());
+
+    // when
+    GraphNodeResponseLog tested = new GraphNodeResponseLog(origin.toJson());
+
+    // then
+    assertNotNull(tested.getLog());
+    assertEquals(EMPTY_SUCCESS_NODE_LOG, tested.getLog());
   }
 }

--- a/task/handler/log/api/src/test/java/io/knotx/fragments/task/handler/log/api/model/GraphNodeResponseLogTest.java
+++ b/task/handler/log/api/src/test/java/io/knotx/fragments/task/handler/log/api/model/GraphNodeResponseLogTest.java
@@ -18,7 +18,7 @@ package io.knotx.fragments.task.handler.log.api.model;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import io.knotx.fragments.api.FragmentResult;
-import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
 import org.junit.jupiter.api.Test;
 
 class GraphNodeResponseLogTest {
@@ -28,16 +28,16 @@ class GraphNodeResponseLogTest {
     // given
     String transition = FragmentResult.SUCCESS_TRANSITION;
 
-    JsonArray invocations = new JsonArray().add("invocation");
+    JsonObject log = new JsonObject().put("debug", "true");
 
-    GraphNodeResponseLog log = GraphNodeResponseLog
-        .newInstance(transition, invocations);
+    GraphNodeResponseLog origin = GraphNodeResponseLog
+        .newInstance(transition, log);
 
     // when
-    GraphNodeResponseLog result = new GraphNodeResponseLog(log.toJson());
+    GraphNodeResponseLog tested = new GraphNodeResponseLog(origin.toJson());
 
     // then
-    assertEquals(transition, result.getTransition());
-    assertEquals(invocations, result.getInvocations());
+    assertEquals(transition, tested.getTransition());
+    assertEquals(log, tested.getLog());
   }
 }


### PR DESCRIPTION
<!-- Please update the sections below that apply, remove the rest -->

## Description
#168 Add errors to the [graph node response log](https://github.com/Knotx/knotx-fragments/blob/master/task/handler/log/api/docs/asciidoc/dataobjects.adoc#graphnoderesponselog).

## Motivation and Context
Propagate all exceptions that happen during node processing to the execution log.

## Upgrade notes (if appropriate)
<!-- What changes user have to do in order to migrate from the previous version to the version with this feature -->
The `response` log syntax in the graph node execution log has changed. As `TaskEngine` is not responsible for retrying node invocations (in case of error transition or an exception), we simplify the structure from:
```
{
  "response": {
    "transition": "_success",
    "invocations": [
      {
        "nodeLogEntry": "value"
      },
      {
        "nodeLogEntry": "value"
      }
    ]
  }
}
```
to
```
{
  "response": {
    "transition": "_success",
    "log": {
      "nodeLogEntry": "value"
    }
  }
}
```
or
```
{
  "response": {
    "transition": "_success",
    "log": {},
    "errors": [
      {
        "className": "java.lang.IllegalStateException",
        "message": "Some error message 1",
        "stackTraceLog": [ "stacktrace entry string representation" ]
      },
      {
        "className": "java.lang.IllegalArgumentException",
        "message": "Some error message 2",
        "stackTraceLog": [ "stacktrace entry string representation" ]
      }
    ]
  }
}
```
Please note that with reactive extension logic we expect that all exceptions (if there is more than once) are wrapped with `CompositeException`, so we expect one or many errors.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/Knotx/knotx/blob/master/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---
I hereby agree to the terms of the Knot.x Contributor License Agreement.
