### PR TITLE
#185 SingleFragmentOperation for asynchronous actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,16 @@ All notable changes to `knotx-fragments` will be documented in this file.
 
 ## Unreleased
 List of changes that are finished but not yet released in any final version.
-- [PR-174](https://github.com/Knotx/knotx-stack/pull/172) - Add node processing errors to the [graph node response log](https://github.com/Knotx/knotx-fragments/blob/master/task/handler/log/api/docs/asciidoc/dataobjects.adoc#graphnoderesponselog).
-- [PR-172](https://github.com/Knotx/knotx-stack/pull/172) - Add a task node processing exception to event log. Remove unused 'TIMEOUT' node status. Update node unit tests.
-- [PR-170](https://github.com/Knotx/knotx-stack/pull/170) - Upgrade to Vert.x `3.9.1`, replace deprecated `setHandler` with `onComplete`.
+- [PR-188](https://github.com/Knotx/knotx-fragments/pull/188) - Exposes nested doActions' (possibly chained) configuration in `OperationMetadata`.
+- [PR-187](https://github.com/Knotx/knotx-fragments/pull/187) - Provides `SingleFragmentOperation` to simplify implementation of RXfied actions.
+- [PR-186](https://github.com/Knotx/knotx-fragments/pull/186) - Provides `FutureFragmentOperation` and `SyncFragmentOperation` to simplify implementation of asynchronous and synchronous actions.
+- [PR-181](https://github.com/Knotx/knotx-fragments/pull/181) - It introduces an error log to `FragmentResult` for handling failures. All `FragmentResult`constructors are deprecated now.
+- [PR-174](https://github.com/Knotx/knotx-fragments/pull/172) - Add node processing errors to the [graph node response log](https://github.com/Knotx/knotx-fragments/blob/master/task/handler/log/api/docs/asciidoc/dataobjects.adoc#graphnoderesponselog).
+- [PR-172](https://github.com/Knotx/knotx-fragments/pull/172) - Add a task node processing exception to event log. Remove unused 'TIMEOUT' node status. Update node unit tests.
+- [PR-170](https://github.com/Knotx/knotx-fragments/pull/170) - Upgrade to Vert.x `3.9.1`, replace deprecated `setHandler` with `onComplete`.
                 
 ## 2.2.1
-- [PR-165](https://github.com/Knotx/knotx-stack/pull/165) - Knotx/knotx-fragments#161 enable passing status code from handlers to end user
+- [PR-165](https://github.com/Knotx/knotx-fragments/pull/165) - Knotx/knotx-fragments#161 enable passing status code from handlers to end user
                 
 ## 2.2.0
 - [PR-154](https://github.com/Knotx/knotx-fragments/pull/154) - Cleanup Fragments modules: renamed modules (`Actions` and all Task related once) to be more self-descriptive. Remove hidden API dependencies.

--- a/action/README.md
+++ b/action/README.md
@@ -58,3 +58,64 @@ cross-cutting functionality e.g HTTP operation can gain the circuit breaker patt
 Below there is a list of core behaviours:
 - [Circuit Breaker Behaviour](https://github.com/Knotx/knotx-fragments/tree/master/action/library#circuit-breaker-behaviour) - it is a kind of quarantine for actions, it uses the [Vert.x Circuit Breaker](https://vertx.io/docs/vertx-circuit-breaker/java/) implementation
 - [In-memory Cache Behaviour](https://github.com/Knotx/knotx-fragments/tree/master/action/library#in-memory-cache-behaviour) - caches a fragment's payload to reduce the number of action invocations
+
+## How to implement a custom Action?
+[Action](#action) has asynchronous nature - it is a [fragment operation](https://github.com/Knotx/knotx-fragments/tree/master/api#fragment-operation).
+However, it can perform a synchronous and asynchronous logic. Knot.x provides template classes to simplify 
+custom actions implementations. See the examples below.  
+
+### Synchronous actions
+`SyncAction` simplifies the implementation of synchronous actions.
+
+```
+public class MySyncActionFactory implements ActionFactory {
+
+  @Override
+  public String getName() {
+    return "my-sync-action";
+  }
+  
+  @Override
+  public Action create(String alias, JsonObject config, Vertx vertx, Action doAction) {
+    return (SyncAction) fragmentContext -> FragmentResult.success(fragmentContext.getFragment());
+  }
+}
+```
+See `SyncFragmentOperationTest` for more details.
+
+### Asynchronous actions
+`FutureAction` and `SingleAction` simplify the implementation of asynchronous actions.
+
+#### Future actions
+```
+class MyFutureActionFactory implements ActionFactory {
+  
+  @Override
+  public String getName() {
+    return "myFutureAction";
+  }
+
+  @Override
+  public Action create(String alias, JsonObject config, Vertx vertx, Action doAction) {
+    return (FutureAction) context -> Future.succeededFuture(FragmentResult.success(context.getFragment()));
+  }
+}
+```
+See `FutureFragmentOperationTest` for more details.
+
+#### ReactiveX actions
+```
+class MySingleActionFactory implements ActionFactory {
+
+  @Override
+  public String getName() {
+    return "myFutureAction";
+  }
+
+  @Override
+  public Action create(String alias, JsonObject config, Vertx vertx, Action doAction) {
+    return (SingleAction) context -> Single.just(FragmentResult.success(context.getFragment()));
+  }
+}
+```
+See `SingleFragmentOperationTest` for more details.

--- a/action/api/src/main/java/io/knotx/fragments/action/api/FutureAction.java
+++ b/action/api/src/main/java/io/knotx/fragments/action/api/FutureAction.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2019 Knot.x Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.knotx.fragments.action.api;
+
+import io.knotx.fragments.api.FutureFragmentOperation;
+
+public interface FutureAction extends Action, FutureFragmentOperation {
+
+}

--- a/action/api/src/main/java/io/knotx/fragments/action/api/SingleAction.java
+++ b/action/api/src/main/java/io/knotx/fragments/action/api/SingleAction.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2019 Knot.x Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.knotx.fragments.action.api;
+
+import io.knotx.fragments.api.SingleFragmentOperation;
+
+public interface SingleAction extends Action, SingleFragmentOperation {
+
+}

--- a/action/library/src/main/java/io/knotx/fragments/action/library/PayloadToBodyActionFactory.java
+++ b/action/library/src/main/java/io/knotx/fragments/action/library/PayloadToBodyActionFactory.java
@@ -33,7 +33,6 @@ import java.util.Optional;
 public class PayloadToBodyActionFactory implements ActionFactory {
 
   private static final String KEY = "key";
-  public static final JsonObject EMPTY_LOG = new JsonObject();
 
   @Override
   public String getName() {
@@ -62,6 +61,6 @@ public class PayloadToBodyActionFactory implements ActionFactory {
 
   private FragmentResult toFragmentResult(Fragment fragment, String body) {
     fragment.setBody(body);
-    return success(fragment, EMPTY_LOG);
+    return success(fragment);
   }
 }

--- a/action/library/src/main/java/io/knotx/fragments/action/library/cb/CircuitBreakerAction.java
+++ b/action/library/src/main/java/io/knotx/fragments/action/library/cb/CircuitBreakerAction.java
@@ -16,24 +16,23 @@
 package io.knotx.fragments.action.library.cb;
 
 import static io.knotx.fragments.action.library.cb.CircuitBreakerActionFactory.FALLBACK_TRANSITION;
+import static io.knotx.fragments.api.FragmentResult.success;
 import static java.lang.String.format;
 import static java.lang.String.valueOf;
 import static java.time.Instant.now;
 
-import io.knotx.fragments.action.api.FutureAction;
-import io.knotx.fragments.api.Fragment;
-import io.knotx.fragments.action.library.exception.DoActionExecuteException;
-import io.knotx.fragments.action.library.helper.TimeCalculator;
 import io.knotx.fragments.action.api.Action;
+import io.knotx.fragments.action.api.FutureAction;
 import io.knotx.fragments.action.api.log.ActionLog;
 import io.knotx.fragments.action.api.log.ActionLogLevel;
 import io.knotx.fragments.action.api.log.ActionLogger;
+import io.knotx.fragments.action.library.exception.DoActionExecuteException;
+import io.knotx.fragments.action.library.helper.TimeCalculator;
+import io.knotx.fragments.api.Fragment;
 import io.knotx.fragments.api.FragmentContext;
 import io.knotx.fragments.api.FragmentResult;
 import io.vertx.circuitbreaker.CircuitBreaker;
-import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
-import io.vertx.core.Handler;
 import io.vertx.core.Promise;
 import io.vertx.core.json.JsonObject;
 import java.util.Set;
@@ -49,7 +48,6 @@ class CircuitBreakerAction implements FutureAction {
   private final Action doAction;
   private final Set<String> errorTransitions;
   private final ActionLogLevel actionLogLevel;
-
 
   CircuitBreakerAction(CircuitBreaker circuitBreaker, Action doAction, String alias,
       ActionLogLevel actionLogLevel, Set<String> errorTransitions) {
@@ -116,8 +114,8 @@ class CircuitBreakerAction implements FutureAction {
       AtomicInteger counter, long startTime, ActionLogger actionLogger) {
     actionLogger.info(INVOCATION_COUNT_LOG_KEY, valueOf(counter.get()));
     actionLogger.doActionLog(TimeCalculator.executionTime(startTime), result.getLog());
-    f.complete(new FragmentResult(result.getFragment(), result.getTransition(),
-        actionLogger.toLog().toJson()));
+    f.complete(
+        success(result.getFragment(), result.getTransition(), actionLogger.toLog().toJson()));
   }
 
   private static FragmentResult handleFallback(FragmentContext fragmentContext,

--- a/action/library/src/main/java/io/knotx/fragments/action/library/http/HttpAction.java
+++ b/action/library/src/main/java/io/knotx/fragments/action/library/http/HttpAction.java
@@ -15,30 +15,28 @@
  */
 package io.knotx.fragments.action.library.http;
 
-import io.knotx.fragments.api.Fragment;
+import io.knotx.fragments.action.api.SingleAction;
+import io.knotx.fragments.action.api.log.ActionLogLevel;
 import io.knotx.fragments.action.library.http.log.HttpActionLogger;
 import io.knotx.fragments.action.library.http.options.EndpointOptions;
 import io.knotx.fragments.action.library.http.options.HttpActionOptions;
+import io.knotx.fragments.action.library.http.payload.ActionPayload;
 import io.knotx.fragments.action.library.http.request.EndpointRequestComposer;
 import io.knotx.fragments.action.library.http.response.EndpointResponse;
 import io.knotx.fragments.action.library.http.response.EndpointResponseProcessor;
-import io.knotx.fragments.action.api.Action;
-import io.knotx.fragments.action.api.log.ActionLogLevel;
+import io.knotx.fragments.api.Fragment;
 import io.knotx.fragments.api.FragmentContext;
 import io.knotx.fragments.api.FragmentResult;
-import io.knotx.fragments.action.library.http.payload.ActionPayload;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.reactivex.Single;
 import io.reactivex.exceptions.Exceptions;
-import io.vertx.core.AsyncResult;
-import io.vertx.core.Future;
-import io.vertx.core.Handler;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 import io.vertx.reactivex.ext.web.client.WebClient;
+
 import java.util.concurrent.TimeoutException;
 
-public class HttpAction implements Action {
+public class HttpAction implements SingleAction {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(HttpAction.class);
 
@@ -62,16 +60,7 @@ public class HttpAction implements Action {
   }
 
   @Override
-  public void apply(FragmentContext fragmentContext,
-      Handler<AsyncResult<FragmentResult>> resultHandler) {
-    Single.just(fragmentContext)
-        .flatMap(this::process)
-        .map(Future::succeededFuture)
-        .map(future -> future.onComplete(resultHandler))
-        .subscribe();
-  }
-
-  private Single<FragmentResult> process(FragmentContext fragmentContext) {
+  public Single<FragmentResult> apply(FragmentContext fragmentContext) {
     HttpActionLogger httpActionLogger = HttpActionLogger
         .create(actionAlias, logLevel, endpointOptions, httpMethod);
     return Single.just(fragmentContext)
@@ -109,8 +98,8 @@ public class HttpAction implements Action {
   }
 
   public static class HttpActionResult {
-    private ActionPayload actionPayload;
-    private String transition;
+    private final ActionPayload actionPayload;
+    private final String transition;
 
     public HttpActionResult(ActionPayload actionPayload, String transition) {
       this.actionPayload = actionPayload;

--- a/action/library/src/main/java/io/knotx/fragments/action/library/http/HttpAction.java
+++ b/action/library/src/main/java/io/knotx/fragments/action/library/http/HttpAction.java
@@ -15,6 +15,8 @@
  */
 package io.knotx.fragments.action.library.http;
 
+import static io.knotx.fragments.api.FragmentResult.success;
+
 import io.knotx.fragments.action.api.SingleAction;
 import io.knotx.fragments.action.api.log.ActionLogLevel;
 import io.knotx.fragments.action.library.http.log.HttpActionLogger;
@@ -80,7 +82,7 @@ public class HttpAction implements SingleAction {
 
   private FragmentResult composeFragmentResult(Fragment fragment, HttpActionResult result, HttpActionLogger httpActionLogger) {
     fragment.appendPayload(actionAlias, result.getActionPayload().toJson());
-    return new FragmentResult(fragment, result.getTransition(), httpActionLogger.getJsonNodeLog());
+    return success(fragment, result.getTransition(), httpActionLogger.getJsonNodeLog());
   }
 
   private static FragmentResult errorTransition(FragmentContext fragmentContext,

--- a/action/library/src/main/java/io/knotx/fragments/action/library/http/log/HttpActionLogger.java
+++ b/action/library/src/main/java/io/knotx/fragments/action/library/http/log/HttpActionLogger.java
@@ -26,9 +26,9 @@ import org.apache.commons.lang3.StringUtils;
 
 public class HttpActionLogger {
 
-  private HttpActionNodeLogger httpActionNodeLogger;
-  private EndpointOptions endpointOptions;
-  private String httpMethod;
+  private final HttpActionNodeLogger httpActionNodeLogger;
+  private final EndpointOptions endpointOptions;
+  private final String httpMethod;
 
   private EndpointRequest endpointRequest;
   private HttpResponseData httpResponseData;

--- a/action/library/src/main/java/io/knotx/fragments/action/library/http/log/HttpActionNodeLogger.java
+++ b/action/library/src/main/java/io/knotx/fragments/action/library/http/log/HttpActionNodeLogger.java
@@ -25,7 +25,7 @@ class HttpActionNodeLogger {
   private static final String RESPONSE = "response";
   private static final String RESPONSE_BODY = "responseBody";
 
-  private ActionLogger actionLogger;
+  private final ActionLogger actionLogger;
 
   private HttpActionNodeLogger(ActionLogger actionLogger) {
     this.actionLogger = actionLogger;

--- a/api/src/main/java/io/knotx/fragments/api/FragmentResult.java
+++ b/api/src/main/java/io/knotx/fragments/api/FragmentResult.java
@@ -39,8 +39,16 @@ public class FragmentResult {
   private final JsonObject log;
   private final FragmentOperationFailure error;
 
+  public static FragmentResult success(Fragment fragment) {
+    return success(fragment, new JsonObject());
+  }
+
+  public static FragmentResult success(Fragment fragment, String transition) {
+    return success(fragment, transition, new JsonObject());
+  }
+
   public static FragmentResult success(Fragment fragment, JsonObject log) {
-    return new FragmentResult(fragment, SUCCESS_TRANSITION, log);
+    return success(fragment, SUCCESS_TRANSITION, log);
   }
 
   public static FragmentResult success(Fragment fragment, String transition, JsonObject log) {

--- a/api/src/main/java/io/knotx/fragments/api/SingleFragmentOperation.java
+++ b/api/src/main/java/io/knotx/fragments/api/SingleFragmentOperation.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2019 Knot.x Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.knotx.fragments.api;
+
+import io.reactivex.Single;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+
+public interface SingleFragmentOperation extends FragmentOperation {
+
+  @Override
+  default void apply(FragmentContext fragmentContext, Handler<AsyncResult<FragmentResult>> resultHandler) {
+    try {
+      Single<FragmentResult> single = apply(fragmentContext);
+      if (single != null) {
+        single.map(Future::succeededFuture)
+            .onErrorReturn(Future::failedFuture)
+            .subscribe(future -> future.onComplete(resultHandler));
+      } else {
+        Future.<FragmentResult>failedFuture(new IllegalStateException(
+            "FutureFragmentOperation " + this.getClass().getName() + " returned a null Single<FragmentResult>.")
+        ).onComplete(resultHandler);
+      }
+    } catch (Throwable t) {
+      Future.<FragmentResult>failedFuture(t).onComplete(resultHandler);
+    }
+  }
+
+  Single<FragmentResult> apply(FragmentContext fragmentContext);
+}

--- a/api/src/test/java/io/knotx/fragments/api/FragmentResultTest.java
+++ b/api/src/test/java/io/knotx/fragments/api/FragmentResultTest.java
@@ -27,32 +27,59 @@ class FragmentResultTest {
 
   private static final Fragment FRAGMENT = new Fragment("snippet",
       new JsonObject().put("configKey", "configValue"), "body value");
-  public static final JsonObject NODE_LOG = new JsonObject().put("nodeLogKey", "nodeLogValue");
+  public static final JsonObject EMPTY_LOG = new JsonObject();
+  public static final JsonObject LOG = new JsonObject().put("nodeLogKey", "nodeLogValue");
+  public static final String CUSTOM = "custom";
 
   @Test
-  @DisplayName("Expect success transition when success")
-  void expectFragmentAndNodeLogWhenSuccess() {
-    FragmentResult origin = FragmentResult.success(FRAGMENT, NODE_LOG);
+  @DisplayName("Expect success transition and log when success")
+  void expectSuccessTransitionAndLogWhenSuccess() {
+    FragmentResult origin = FragmentResult.success(FRAGMENT, LOG);
     FragmentResult copy = new FragmentResult(origin.toJson());
 
     assertEquals(origin, copy);
     assertEquals(FRAGMENT, copy.getFragment());
     assertEquals(SUCCESS_TRANSITION, copy.getTransition());
-    assertEquals(NODE_LOG, copy.getLog());
+    assertEquals(LOG, copy.getLog());
     assertNull(copy.getError());
   }
 
   @Test
-  @DisplayName("Expect custom transition success with custom")
-  void expectFragmentAndCustomTransitionAndNodeLogWhenSuccessWithCustomTransition() {
-    String customTransition = "custom";
-    FragmentResult origin = FragmentResult.success(FRAGMENT, customTransition, NODE_LOG);
+  @DisplayName("Expect success transition and empty log when success without log")
+  void expectSuccessTransitionAndEmptyLogWhenSuccess() {
+    FragmentResult origin = FragmentResult.success(FRAGMENT);
     FragmentResult copy = new FragmentResult(origin.toJson());
 
     assertEquals(origin, copy);
     assertEquals(FRAGMENT, copy.getFragment());
-    assertEquals(customTransition, copy.getTransition());
-    assertEquals(NODE_LOG, copy.getLog());
+    assertEquals(SUCCESS_TRANSITION, copy.getTransition());
+    assertEquals(EMPTY_LOG, copy.getLog());
+    assertNull(copy.getError());
+  }
+
+  @Test
+  @DisplayName("Expect custom transition and log when success with custom transition")
+  void expectCustomTransitionAndLogWhenSuccessWithCustomTransition() {
+    FragmentResult origin = FragmentResult.success(FRAGMENT, CUSTOM, LOG);
+    FragmentResult copy = new FragmentResult(origin.toJson());
+
+    assertEquals(origin, copy);
+    assertEquals(FRAGMENT, copy.getFragment());
+    assertEquals(CUSTOM, copy.getTransition());
+    assertEquals(LOG, copy.getLog());
+    assertNull(copy.getError());
+  }
+
+  @Test
+  @DisplayName("Expect custom transition and empty log when success with custom transition without log")
+  void expectCustomTransitionAndEmptyLogWhenSuccess() {
+    FragmentResult origin = FragmentResult.success(FRAGMENT, CUSTOM);
+    FragmentResult copy = new FragmentResult(origin.toJson());
+
+    assertEquals(origin, copy);
+    assertEquals(FRAGMENT, copy.getFragment());
+    assertEquals(CUSTOM, copy.getTransition());
+    assertEquals(EMPTY_LOG, copy.getLog());
     assertNull(copy.getError());
   }
 

--- a/api/src/test/java/io/knotx/fragments/api/FutureFragmentOperationTest.java
+++ b/api/src/test/java/io/knotx/fragments/api/FutureFragmentOperationTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2019 Knot.x Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.knotx.fragments.api;
+
+import static io.knotx.fragments.api.TestUtils.FRAGMENT_RESULT;
+import static io.knotx.fragments.api.TestUtils.assertFailureDelivered;
+import static io.knotx.fragments.api.TestUtils.assertSuccessDelivered;
+
+import io.knotx.junit5.KnotxExtension;
+import io.vertx.core.Future;
+import io.vertx.junit5.VertxTestContext;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(KnotxExtension.class)
+class FutureFragmentOperationTest {
+
+  @Test
+  @DisplayName("Expect succeeded AsyncResult when operation returns succeeded future")
+  void succeedingOperation(VertxTestContext testContext) throws InterruptedException {
+    FutureFragmentOperation tested = fragmentContext -> Future.succeededFuture(FRAGMENT_RESULT);
+
+    assertSuccessDelivered(testContext, tested);
+  }
+
+  @Test
+  @DisplayName("Expect failed AsyncResult when operation returns null future")
+  void nullOperation(VertxTestContext testContext) throws InterruptedException {
+    FutureFragmentOperation tested = fragmentContext -> null;
+
+    assertFailureDelivered(testContext, tested, IllegalStateException.class);
+  }
+
+  @Test
+  @DisplayName("Expect failed AsyncResult when operation returns failed future")
+  void failedFutureOperation(VertxTestContext testContext) throws InterruptedException {
+    FutureFragmentOperation tested = fragmentContext -> Future.failedFuture(new RuntimeException());
+
+    assertFailureDelivered(testContext, tested, RuntimeException.class);
+  }
+
+  @Test
+  @DisplayName("Expect failed AsyncResult when operation throws")
+  void throwingOperation(VertxTestContext testContext) throws InterruptedException {
+    FutureFragmentOperation tested = fragmentContext -> {
+      throw new RuntimeException();
+    };
+
+    assertFailureDelivered(testContext, tested, RuntimeException.class);
+  }
+
+}

--- a/api/src/test/java/io/knotx/fragments/api/SingleFragmentOperationTest.java
+++ b/api/src/test/java/io/knotx/fragments/api/SingleFragmentOperationTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2019 Knot.x Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.knotx.fragments.api;
+
+import static io.knotx.fragments.api.TestUtils.FRAGMENT_RESULT;
+import static io.knotx.fragments.api.TestUtils.assertFailureDelivered;
+import static io.knotx.fragments.api.TestUtils.assertSuccessDelivered;
+
+import io.knotx.junit5.KnotxExtension;
+import io.reactivex.Single;
+import io.vertx.junit5.VertxTestContext;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(KnotxExtension.class)
+class SingleFragmentOperationTest {
+
+  @Test
+  @DisplayName("Expect succeeded AsyncResult when operation returns succeeding single")
+  void succeedingOperation(VertxTestContext testContext) throws InterruptedException {
+    SingleFragmentOperation tested = fragmentContext -> Single.just(FRAGMENT_RESULT);
+
+    assertSuccessDelivered(testContext, tested);
+  }
+
+  @Test
+  @DisplayName("Expect failed AsyncResult when operation returns null")
+  void nullOperation(VertxTestContext testContext) throws InterruptedException {
+    SingleFragmentOperation tested = fragmentContext -> null;
+
+    assertFailureDelivered(testContext, tested, IllegalStateException.class);
+  }
+
+  @Test
+  @DisplayName("Expect failed AsyncResult when operation returns failing single")
+  void failingOperation(VertxTestContext testContext) throws InterruptedException {
+    SingleFragmentOperation tested = fragmentContext -> Single.error(new RuntimeException());
+
+    assertFailureDelivered(testContext, tested, RuntimeException.class);
+  }
+
+  @Test
+  @DisplayName("Expect failed AsyncResult when operation throws")
+  void throwingOperation(VertxTestContext testContext) throws InterruptedException {
+    SingleFragmentOperation tested = fragmentContext -> {
+      throw new RuntimeException();
+    };
+
+    assertFailureDelivered(testContext, tested, RuntimeException.class);
+  }
+
+}

--- a/api/src/test/java/io/knotx/fragments/api/SyncFragmentOperationTest.java
+++ b/api/src/test/java/io/knotx/fragments/api/SyncFragmentOperationTest.java
@@ -35,12 +35,11 @@ class SyncFragmentOperationTest {
   private static final Fragment FRAGMENT = new Fragment("", new JsonObject(), "");
   private static final FragmentContext FRAGMENT_CONTEXT = new FragmentContext(FRAGMENT,
       new ClientRequest());
-  public static final JsonObject EMPTY_LOG = new JsonObject();
 
   @Test
   @DisplayName("Expect succeeded AsyncResult when operation succeeds")
   void succeedingOperation(VertxTestContext testContext) throws InterruptedException {
-    SyncFragmentOperation tested = fragmentContext -> FragmentResult.success(FRAGMENT, EMPTY_LOG);
+    SyncFragmentOperation tested = fragmentContext -> FragmentResult.success(FRAGMENT);
 
     callOperation(testContext, tested, asyncResult -> {
       assertTrue(asyncResult.succeeded());

--- a/api/src/test/java/io/knotx/fragments/api/SyncFragmentOperationTest.java
+++ b/api/src/test/java/io/knotx/fragments/api/SyncFragmentOperationTest.java
@@ -57,6 +57,7 @@ class SyncFragmentOperationTest {
       assertTrue(asyncResult.succeeded());
       testContext.completeNow();
     });
+
   }
 
   @Test

--- a/api/src/test/java/io/knotx/fragments/api/TestUtils.java
+++ b/api/src/test/java/io/knotx/fragments/api/TestUtils.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2019 Knot.x Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.knotx.fragments.api;
+
+import static io.knotx.fragments.api.FragmentResult.SUCCESS_TRANSITION;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.knotx.server.api.context.ClientRequest;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
+import io.vertx.core.json.JsonObject;
+import io.vertx.junit5.VertxTestContext;
+
+import java.util.concurrent.TimeUnit;
+
+public final class TestUtils {
+
+  static final Fragment FRAGMENT = new Fragment("", new JsonObject(), "");
+  static final FragmentContext FRAGMENT_CONTEXT = new FragmentContext(FRAGMENT, new ClientRequest());
+  static final FragmentResult FRAGMENT_RESULT = new FragmentResult(FRAGMENT, SUCCESS_TRANSITION);
+
+  private TestUtils() {
+    // utility class
+  }
+
+  static void assertSuccessDelivered(VertxTestContext testContext, FragmentOperation operation)
+      throws InterruptedException {
+    callOperation(testContext, operation, asyncResult -> {
+      assertTrue(asyncResult.succeeded());
+      testContext.completeNow();
+    });
+  }
+
+  static void assertFailureDelivered(VertxTestContext testContext, FragmentOperation operation)
+      throws InterruptedException {
+    callOperation(testContext, operation, asyncResult -> {
+      assertTrue(asyncResult.failed());
+      testContext.completeNow();
+    });
+  }
+
+  static void assertFailureDelivered(VertxTestContext testContext, FragmentOperation operation, Class<? extends Throwable> exceptionClass)
+      throws InterruptedException {
+    callOperation(testContext, operation, asyncResult -> {
+      assertTrue(asyncResult.failed());
+      assertEquals(exceptionClass, asyncResult.cause().getClass());
+      testContext.completeNow();
+    });
+  }
+
+  private static void callOperation(VertxTestContext testContext, FragmentOperation operation,
+                                    Handler<AsyncResult<FragmentResult>> assertions) throws InterruptedException {
+    operation.apply(FRAGMENT_CONTEXT, assertions);
+    testContext.awaitCompletion(1000, TimeUnit.MILLISECONDS);
+  }
+
+}


### PR DESCRIPTION
## Description
Provides `SingleFragmentOperation` and `SingleAction` that encapsulate actions that return `Single<FragmentResult>`.
Attaches `HttpAction` and `InMemoryCacheAction` to use these interfaces.
Attaches `CircuitBreakerAction` to use `FutureAction` interface.
Provides unit tests to confirm error handling.

## Motivation and Context
#185 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/Knotx/knotx/blob/master/CONTRIBUTING.md) document.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---
I hereby agree to the terms of the Knot.x Contributor License Agreement.
