### PR TITLE
Rename doActionLogs to invocations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@ All notable changes to `knotx-fragments` will be documented in this file.
 
 ## Unreleased
 List of changes that are finished but not yet released in any final version.
-- [PR-195](https://github.com/Knotx/knotx-fragments/pull/195) - Simplifies `ActionProvider`'s constructor
+- [PR-196](https://github.com/Knotx/knotx-fragments/pull/196/files) - Rename `doActionLogs`  in [Actions](https://github.com/Knotx/knotx-fragments/tree/master/action)' log to `invocations`.
+- [PR-195](https://github.com/Knotx/knotx-fragments/pull/195) - Simplifies `ActionProvider`'s constructor.
 - [PR-194](https://github.com/Knotx/knotx-fragments/pull/194) - Generalizes `InMemoryCacheAction` to support different `Cache` implementations. Provides test refactoring.
 - [PR-188](https://github.com/Knotx/knotx-fragments/pull/188) - Exposes nested doActions' (possibly chained) configuration in `OperationMetadata`.
 - [PR-187](https://github.com/Knotx/knotx-fragments/pull/187) - Provides `SingleFragmentOperation` to simplify implementation of RXfied actions.

--- a/action/api/build.gradle.kts
+++ b/action/api/build.gradle.kts
@@ -31,6 +31,7 @@ dependencies {
     api(project(":knotx-fragments-api"))
 
     implementation(platform("io.knotx:knotx-dependencies:${project.version}"))
+    implementation("io.knotx:knotx-commons:${project.version}")
     implementation(group = "io.vertx", name = "vertx-core")
     implementation(group = "io.vertx", name = "vertx-service-proxy")
     implementation(group = "io.vertx", name = "vertx-rx-java2")

--- a/action/api/docs/asciidoc/dataobjects.adoc
+++ b/action/api/docs/asciidoc/dataobjects.adoc
@@ -8,8 +8,8 @@
 [frame="topbot"]
 |===
 ^|Name | Type ^| Description
-|[[doActionLog]]`@doActionLog`|`link:dataobjects.html#ActionLog[ActionLog]`|-
 |[[duration]]`@duration`|`Number (Long)`|-
+|[[log]]`@log`|`link:dataobjects.html#ActionLog[ActionLog]`|-
 |[[success]]`@success`|`Boolean`|-
 |===
 

--- a/action/api/src/main/java/io/knotx/fragments/action/api/log/ActionInvocationLog.java
+++ b/action/api/src/main/java/io/knotx/fragments/action/api/log/ActionInvocationLog.java
@@ -27,9 +27,9 @@ import io.vertx.core.json.JsonObject;
  */
 public class ActionInvocationLog {
 
-  static final String DURATION = "duration";
-  static final String SUCCESS = "success";
-  static final String DO_ACTION_LOG = "doActionLog";
+  public static final String DURATION = "duration";
+  public static final String SUCCESS = "success";
+  public static final String LOG = "log";
 
   /**
    * Action processing time in milliseconds.
@@ -44,18 +44,18 @@ public class ActionInvocationLog {
   /**
    * Enveloped action log.
    */
-  private final ActionLog doActionLog;
+  private final ActionLog log;
 
-  private ActionInvocationLog(long duration, boolean success, ActionLog doActionLog) {
+  private ActionInvocationLog(long duration, boolean success, ActionLog log) {
     this.duration = duration;
     this.success = success;
-    this.doActionLog = doActionLog;
+    this.log = log;
   }
 
   public ActionInvocationLog(JsonObject json) {
     this.duration = json.getLong(DURATION);
     this.success = json.getBoolean(SUCCESS);
-    this.doActionLog = toDoActionLog(json);
+    this.log = toLog(json);
   }
 
   static ActionInvocationLog success(long duration, ActionLog actionLog) {
@@ -74,14 +74,14 @@ public class ActionInvocationLog {
     return success;
   }
 
-  public ActionLog getDoActionLog() {
-    return doActionLog;
+  public ActionLog getLog() {
+    return log;
   }
 
   public JsonObject toJson() {
-    return new JsonObject().put("duration", duration)
-        .put("success", success)
-        .put("doActionLog", doActionLog != null ? doActionLog.toJson() : null);
+    return new JsonObject().put(DURATION, duration)
+        .put(SUCCESS, success)
+        .put(LOG, log != null ? log.toJson() : null);
   }
 
   @Override
@@ -95,12 +95,12 @@ public class ActionInvocationLog {
     ActionInvocationLog that = (ActionInvocationLog) o;
     return success == that.success &&
         Objects.equals(duration, that.duration) &&
-        Objects.equals(doActionLog, that.doActionLog);
+        Objects.equals(log, that.log);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(duration, success, doActionLog);
+    return Objects.hash(duration, success, log);
   }
 
   @Override
@@ -108,13 +108,13 @@ public class ActionInvocationLog {
     return "ActionInvocationLog{" +
         "duration=" + duration +
         ", success=" + success +
-        ", doActionLog=" + doActionLog +
+        ", log=" + log +
         '}';
   }
 
-  private ActionLog toDoActionLog(JsonObject json) {
+  private ActionLog toLog(JsonObject json) {
     return Optional.ofNullable(json)
-        .map(j -> j.getJsonObject(DO_ACTION_LOG))
+        .map(j -> j.getJsonObject(LOG))
         .map(ActionLog::new)
         .orElse(null);
   }

--- a/action/api/src/main/java/io/knotx/fragments/action/api/log/ActionLogBuilder.java
+++ b/action/api/src/main/java/io/knotx/fragments/action/api/log/ActionLogBuilder.java
@@ -24,22 +24,22 @@ import java.util.ArrayList;
 
 class ActionLogBuilder {
 
-  private String alias;
-  private JsonObject logs;
-  private ArrayList<ActionInvocationLog> doActionLogs;
+  private final String alias;
+  private final JsonObject logs;
+  private final ArrayList<ActionInvocationLog> invocations;
 
   ActionLogBuilder(String alias) {
     this.alias = alias;
     this.logs = new JsonObject();
-    this.doActionLogs = new ArrayList<>();
+    this.invocations = new ArrayList<>();
   }
 
   void appendInvocationLogEntry(long duration, ActionLog actionLog) {
-    doActionLogs.add(success(duration, actionLog));
+    invocations.add(success(duration, actionLog));
   }
 
   void appendFailureInvocationLogEntry(long duration, ActionLog actionLog) {
-    doActionLogs.add(error(duration, actionLog));
+    invocations.add(error(duration, actionLog));
   }
 
   void addLog(String key, String value) {
@@ -55,6 +55,6 @@ class ActionLogBuilder {
   }
 
   ActionLog build() {
-    return new ActionLog(alias, logs, doActionLogs);
+    return new ActionLog(alias, logs, invocations);
   }
 }

--- a/action/api/src/test/java/io/knotx/fragments/action/api/log/ActionInvocationLogTest.java
+++ b/action/api/src/test/java/io/knotx/fragments/action/api/log/ActionInvocationLogTest.java
@@ -16,7 +16,7 @@
 package io.knotx.fragments.action.api.log;
 
 
-import static io.knotx.fragments.action.api.log.ActionInvocationLog.DO_ACTION_LOG;
+import static io.knotx.fragments.action.api.log.ActionInvocationLog.LOG;
 import static io.knotx.fragments.action.api.log.ActionInvocationLog.DURATION;
 import static io.knotx.fragments.action.api.log.ActionInvocationLog.SUCCESS;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -39,8 +39,8 @@ class ActionInvocationLogTest {
     ActionInvocationLog invocationLog = new ActionInvocationLog(json);
 
     //then
-    assertNull(invocationLog.getDoActionLog());
-    assertNull(invocationLog.toJson().getJsonObject(DO_ACTION_LOG));
+    assertNull(invocationLog.getLog());
+    assertNull(invocationLog.toJson().getJsonObject(LOG));
   }
 
   @Test
@@ -50,13 +50,13 @@ class ActionInvocationLogTest {
     ActionLog al = new ActionLog("alias", new JsonObject(), Collections.emptyList());
     JsonObject json = new JsonObject().put(DURATION, 1L)
         .put(SUCCESS, true)
-        .put(DO_ACTION_LOG, al.toJson());
+        .put(LOG, al.toJson());
 
     //when
     ActionInvocationLog invocationLog = new ActionInvocationLog(json);
 
     //then
-    assertNotNull(invocationLog.getDoActionLog());
-    assertNotNull(invocationLog.toJson().getJsonObject(DO_ACTION_LOG));
+    assertNotNull(invocationLog.getLog());
+    assertNotNull(invocationLog.toJson().getJsonObject(LOG));
   }
 }

--- a/action/library/src/main/java/io/knotx/fragments/action/library/cache/operations/CacheActionLogger.java
+++ b/action/library/src/main/java/io/knotx/fragments/action/library/cache/operations/CacheActionLogger.java
@@ -55,9 +55,9 @@ public class CacheActionLogger {
   public void onRetrieveEnd(FragmentResult fragmentResult) {
     long executionTime = TimeCalculator.millisFrom(retrieveStart);
     if (isSuccessTransition(fragmentResult)) {
-      actionLogger.doActionLog(executionTime, fragmentResult.getLog());
+      actionLogger.invocation(executionTime, fragmentResult.getLog());
     } else {
-      actionLogger.failureDoActionLog(executionTime, fragmentResult.getLog());
+      actionLogger.failedInvocation(executionTime, fragmentResult.getLog());
     }
   }
 

--- a/action/library/src/main/java/io/knotx/fragments/action/library/cb/CircuitBreakerAction.java
+++ b/action/library/src/main/java/io/knotx/fragments/action/library/cb/CircuitBreakerAction.java
@@ -107,14 +107,14 @@ class CircuitBreakerAction implements FutureAction {
 
   private static void handleFail(Promise<FragmentResult> promise, JsonObject nodeLog,
       long startTime, Throwable error, ActionLogger actionLogger) {
-    actionLogger.failureDoActionLog(millisFrom(startTime), nodeLog);
+    actionLogger.failedInvocation(millisFrom(startTime), nodeLog);
     promise.fail(error);
   }
 
   private static void handleSuccess(Promise<FragmentResult> f, FragmentResult result,
       AtomicInteger counter, long startTime, ActionLogger actionLogger) {
     actionLogger.info(INVOCATION_COUNT_LOG_KEY, valueOf(counter.get()));
-    actionLogger.doActionLog(millisFrom(startTime), result.getLog());
+    actionLogger.invocation(millisFrom(startTime), result.getLog());
     f.complete(
         success(result.getFragment(), result.getTransition(), actionLogger.toLog().toJson()));
   }

--- a/action/library/src/main/java/io/knotx/fragments/action/library/exception/DoActionExecuteException.java
+++ b/action/library/src/main/java/io/knotx/fragments/action/library/exception/DoActionExecuteException.java
@@ -12,8 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * The code comes from https://github.com/tomaszmichalak/vertx-rx-map-reduce.
  */
 package io.knotx.fragments.action.library.exception;
 

--- a/action/library/src/main/java/io/knotx/fragments/action/library/exception/DoActionNotDefinedException.java
+++ b/action/library/src/main/java/io/knotx/fragments/action/library/exception/DoActionNotDefinedException.java
@@ -12,8 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * The code comes from https://github.com/tomaszmichalak/vertx-rx-map-reduce.
  */
 package io.knotx.fragments.action.library.exception;
 

--- a/action/library/src/test/java/io/knotx/fragments/action/library/cache/CacheActionTest.java
+++ b/action/library/src/test/java/io/knotx/fragments/action/library/cache/CacheActionTest.java
@@ -15,12 +15,14 @@
  */
 package io.knotx.fragments.action.library.cache;
 
+import static io.knotx.fragments.action.api.log.ActionInvocationLog.LOG;
+import static io.knotx.fragments.action.api.log.ActionInvocationLog.SUCCESS;
+import static io.knotx.fragments.action.api.log.ActionLog.INVOCATIONS;
 import static io.knotx.fragments.action.library.TestUtils.successResult;
 import static io.knotx.fragments.action.library.TestUtils.verifyActionResult;
 import static io.knotx.fragments.action.library.cache.CacheTestUtils.ACTION_ALIAS;
+import static io.knotx.fragments.action.library.cache.CacheTestUtils.ACTION_LOG;
 import static io.knotx.fragments.action.library.cache.CacheTestUtils.CACHE_KEY;
-import static io.knotx.fragments.action.library.cache.CacheTestUtils.DO_ACTION_LOGS;
-import static io.knotx.fragments.action.library.cache.CacheTestUtils.INVOCATIONS_LOGS_KEY;
 import static io.knotx.fragments.action.library.cache.CacheTestUtils.LOGS_KEY;
 import static io.knotx.fragments.action.library.cache.CacheTestUtils.PAYLOAD_KEY;
 import static io.knotx.fragments.action.library.cache.CacheTestUtils.SOME_VALUE;
@@ -133,10 +135,10 @@ class CacheActionTest {
     Action tested = create(doActionIdleWithLogs());
 
     JsonObject expected = new JsonObject()
-        .put(INVOCATIONS_LOGS_KEY, new JsonArray()
+        .put(INVOCATIONS, new JsonArray()
             .add(new JsonObject()
-                .put("success", true)
-                .put("doActionLog", DO_ACTION_LOGS)));
+                .put(SUCCESS, true)
+                .put(LOG, ACTION_LOG)));
 
     verifyActionResult(testContext, tested,
         result -> assertJsonEquals(expected, result.result().getLog()));

--- a/action/library/src/test/java/io/knotx/fragments/action/library/cache/CacheTestUtils.java
+++ b/action/library/src/test/java/io/knotx/fragments/action/library/cache/CacheTestUtils.java
@@ -15,6 +15,9 @@
  */
 package io.knotx.fragments.action.library.cache;
 
+import static io.knotx.fragments.action.api.log.ActionLog.ALIAS;
+import static io.knotx.fragments.action.api.log.ActionLog.INVOCATIONS;
+import static io.knotx.fragments.action.api.log.ActionLog.LOGS;
 import static io.knotx.fragments.action.library.TestUtils.someFragment;
 
 import io.knotx.commons.cache.Cache;
@@ -34,13 +37,11 @@ public final class CacheTestUtils {
   public static final String PAYLOAD_KEY = "payloadKey";
   public static final JsonObject SOME_VALUE = new JsonObject().put("configuration", "value");
 
-  public static final String INVOCATIONS_LOGS_KEY = "doActionLogs";
-
-  public static final JsonObject DO_ACTION_LOGS = new JsonObject()
-      .put("alias", "some-do-action")
-      .put("logs", new JsonObject()
+  public static final JsonObject ACTION_LOG = new JsonObject()
+      .put(ALIAS, "some-do-action")
+      .put(LOGS, new JsonObject()
           .put("InnerInfo", "InnerValue"))
-      .put("doActionLogs", new JsonArray());
+      .put(INVOCATIONS, new JsonArray());
 
   private CacheTestUtils() {
     // Utility class
@@ -102,12 +103,12 @@ public final class CacheTestUtils {
 
   public static Action doActionIdleWithLogs() {
     return (SyncAction) fragmentContext -> FragmentResult
-        .success(fragmentContext.getFragment(), DO_ACTION_LOGS);
+        .success(fragmentContext.getFragment(), ACTION_LOG);
   }
 
   public static Action doActionError() {
     return (SyncAction) fragmentContext -> FragmentResult
-        .fail(fragmentContext.getFragment(), DO_ACTION_LOGS, new RuntimeException());
+        .fail(fragmentContext.getFragment(), ACTION_LOG, new RuntimeException());
   }
 
   public static Action doActionAppending() {

--- a/action/library/src/test/java/io/knotx/fragments/action/library/cache/operations/CacheActionLoggerTest.java
+++ b/action/library/src/test/java/io/knotx/fragments/action/library/cache/operations/CacheActionLoggerTest.java
@@ -94,7 +94,7 @@ class CacheActionLoggerTest {
     tested.onRetrieveStart();
     tested.onRetrieveEnd(successResult());
 
-    verify(actionLogger, times(1)).doActionLog(anyLong(), any());
+    verify(actionLogger, times(1)).invocation(anyLong(), any());
   }
 
   @Test
@@ -104,7 +104,7 @@ class CacheActionLoggerTest {
     tested.onRetrieveStart();
     tested.onRetrieveEnd(failedResult());
 
-    verify(actionLogger, times(1)).failureDoActionLog(anyLong(), any());
+    verify(actionLogger, times(1)).failedInvocation(anyLong(), any());
   }
 
   @Test
@@ -129,7 +129,7 @@ class CacheActionLoggerTest {
 
   private Long getLoggedDuration() {
     ArgumentCaptor<Long> duration = ArgumentCaptor.forClass(Long.class);
-    verify(actionLogger, times(1)).doActionLog(duration.capture(), any());
+    verify(actionLogger, times(1)).invocation(duration.capture(), any());
     return duration.getValue();
   }
 

--- a/action/library/src/test/java/io/knotx/fragments/action/library/cb/CircuitBreakerActionFactoryTest.java
+++ b/action/library/src/test/java/io/knotx/fragments/action/library/cb/CircuitBreakerActionFactoryTest.java
@@ -366,11 +366,11 @@ class CircuitBreakerActionFactoryTest {
 
             ActionInvocationLog invocationLog1 = doActionsLogs.get(0);
             assertFalse(invocationLog1.isSuccess());
-            assertNull(invocationLog1.getDoActionLog());
+            assertNull(invocationLog1.getLog());
 
             ActionInvocationLog invocationLog2 = doActionsLogs.get(1);
             assertTrue(invocationLog2.isSuccess());
-            assertNotNull(invocationLog2.getDoActionLog());
+            assertNotNull(invocationLog2.getLog());
           });
           testContext.completeNow();
         }, testContext, vertx);
@@ -396,11 +396,11 @@ class CircuitBreakerActionFactoryTest {
 
             ActionInvocationLog invocationLog1 = doActionsLogs.get(0);
             assertFalse(invocationLog1.isSuccess());
-            assertNotNull(invocationLog1.getDoActionLog());
+            assertNotNull(invocationLog1.getLog());
 
             ActionInvocationLog invocationLog2 = doActionsLogs.get(1);
             assertTrue(invocationLog2.isSuccess());
-            assertNotNull(invocationLog2.getDoActionLog());
+            assertNotNull(invocationLog2.getLog());
 
           });
           testContext.completeNow();
@@ -429,11 +429,11 @@ class CircuitBreakerActionFactoryTest {
 
             ActionInvocationLog invocationLog1 = doActionsLogs.get(0);
             assertFalse(invocationLog1.isSuccess());
-            assertNull(invocationLog1.getDoActionLog());
+            assertNull(invocationLog1.getLog());
 
             ActionInvocationLog invocationLog2 = doActionsLogs.get(1);
             assertFalse(invocationLog2.isSuccess());
-            assertNotNull(invocationLog2.getDoActionLog());
+            assertNotNull(invocationLog2.getLog());
           });
           testContext.completeNow();
         }, testContext, vertx);
@@ -459,7 +459,7 @@ class CircuitBreakerActionFactoryTest {
             assertEquals("2", invocationCount);
             ActionInvocationLog invocationLog1 = doActionsLogs.get(0);
             assertFalse(invocationLog1.isSuccess());
-            assertNull(invocationLog1.getDoActionLog());
+            assertNull(invocationLog1.getLog());
           });
           testContext.completeNow();
         }, testContext, vertx);
@@ -487,7 +487,7 @@ class CircuitBreakerActionFactoryTest {
 
             ActionInvocationLog invocationLog1 = doActionsLogs.get(0);
             assertFalse(invocationLog1.isSuccess());
-            assertNull(invocationLog1.getDoActionLog());
+            assertNull(invocationLog1.getLog());
           });
           testContext.completeNow();
         }, testContext, vertx

--- a/action/library/src/test/java/io/knotx/fragments/action/library/logging/InMemoryCacheActionFactoryLoggingTest.java
+++ b/action/library/src/test/java/io/knotx/fragments/action/library/logging/InMemoryCacheActionFactoryLoggingTest.java
@@ -17,11 +17,13 @@
  */
 package io.knotx.fragments.action.library.logging;
 
+import static io.knotx.fragments.action.api.log.ActionInvocationLog.LOG;
+import static io.knotx.fragments.action.api.log.ActionInvocationLog.SUCCESS;
+import static io.knotx.fragments.action.api.log.ActionLog.INVOCATIONS;
 import static io.knotx.fragments.action.library.TestUtils.someContext;
 import static io.knotx.fragments.action.library.TestUtils.verifyActionResult;
 import static io.knotx.fragments.action.library.TestUtils.verifyTwoActionResults;
-import static io.knotx.fragments.action.library.cache.CacheTestUtils.DO_ACTION_LOGS;
-import static io.knotx.fragments.action.library.cache.CacheTestUtils.INVOCATIONS_LOGS_KEY;
+import static io.knotx.fragments.action.library.cache.CacheTestUtils.ACTION_LOG;
 import static io.knotx.fragments.action.library.cache.CacheTestUtils.LOGS_KEY;
 import static io.knotx.fragments.action.library.cache.CacheTestUtils.PAYLOAD_KEY;
 import static io.knotx.fragments.action.library.cache.CacheTestUtils.SOME_VALUE;
@@ -40,7 +42,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.knotx.fragments.action.api.Action;
 import io.knotx.fragments.action.library.InMemoryCacheActionFactory;
-import io.knotx.junit5.KnotxExtension;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.junit5.VertxExtension;
@@ -89,7 +90,7 @@ class InMemoryCacheActionFactoryLoggingTest {
     Action tested = create(doActionIdleWithLogs(), ERROR);
 
     verifyLog(testContext, tested,
-        log -> assertTrue(log.getJsonArray(INVOCATIONS_LOGS_KEY).isEmpty()));
+        log -> assertTrue(log.getJsonArray(INVOCATIONS).isEmpty()));
   }
 
   @Test
@@ -125,10 +126,10 @@ class InMemoryCacheActionFactoryLoggingTest {
     Action tested = create(doActionIdleWithLogs(), INFO);
 
     JsonObject expected = new JsonObject()
-        .put(INVOCATIONS_LOGS_KEY, new JsonArray()
+        .put(INVOCATIONS, new JsonArray()
             .add(new JsonObject()
-                .put("success", true)
-                .put("doActionLog", DO_ACTION_LOGS)));
+                .put(SUCCESS, true)
+                .put(LOG, ACTION_LOG)));
 
     verifyLog(testContext, tested, log -> assertJsonEquals(expected, log));
   }
@@ -140,10 +141,10 @@ class InMemoryCacheActionFactoryLoggingTest {
     Action tested = create(doActionError(), level);
 
     JsonObject expected = new JsonObject()
-        .put(INVOCATIONS_LOGS_KEY, new JsonArray()
+        .put(INVOCATIONS, new JsonArray()
             .add(new JsonObject()
-                .put("success", false)
-                .put("doActionLog", DO_ACTION_LOGS)));
+                .put(SUCCESS, false)
+                .put(LOG, ACTION_LOG)));
 
     verifyLog(testContext, tested, log -> assertJsonEquals(expected, log));
   }

--- a/action/library/src/test/java/io/knotx/fragments/action/library/logging/InMemoryCacheActionFactoryLoggingTest.java
+++ b/action/library/src/test/java/io/knotx/fragments/action/library/logging/InMemoryCacheActionFactoryLoggingTest.java
@@ -12,8 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * The code comes from https://github.com/tomaszmichalak/vertx-rx-map-reduce.
  */
 package io.knotx.fragments.action.library.logging;
 

--- a/action/library/src/test/java/io/knotx/fragments/action/library/logging/InlineBodyActionFactoryLoggingTest.java
+++ b/action/library/src/test/java/io/knotx/fragments/action/library/logging/InlineBodyActionFactoryLoggingTest.java
@@ -15,6 +15,8 @@
  */
 package io.knotx.fragments.action.library.logging;
 
+import static io.knotx.fragments.action.api.log.ActionLog.INVOCATIONS;
+import static io.knotx.fragments.action.api.log.ActionLog.LOGS;
 import static io.knotx.fragments.action.library.TestUtils.ACTION_ALIAS;
 import static io.knotx.fragments.action.library.TestUtils.someFragment;
 import static io.knotx.fragments.action.library.TestUtils.verifyActionResult;
@@ -37,9 +39,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 @Timeout(value = 5, timeUnit = SECONDS)
 class InlineBodyActionFactoryLoggingTest {
 
-  private static final String LOGS_KEY = "logs";
-  private static final String DO_ACTION_LOGS_KEY = "doActionLogs";
-
   private static final String BODY_TO_INLINE = "body to inline";
   private static final String INITIAL_BODY = "initial body";
 
@@ -58,7 +57,7 @@ class InlineBodyActionFactoryLoggingTest {
 
     // when
     verifyActionResult(testContext, action, someFragment().setBody(INITIAL_BODY), result -> {
-      JsonObject logs = result.result().getLog().getJsonObject(LOGS_KEY);
+      JsonObject logs = result.result().getLog().getJsonObject(LOGS);
       assertEquals(INITIAL_BODY, logs.getString(ORIGINAL_BODY_KEY));
       assertEquals(BODY_TO_INLINE, logs.getString(BODY_KEY));
     });
@@ -77,8 +76,8 @@ class InlineBodyActionFactoryLoggingTest {
     // when
     verifyActionResult(testContext, action, someFragment().setBody(INITIAL_BODY), result -> {
       JsonObject logs = result.result().getLog();
-      assertTrue(logs.getJsonObject(LOGS_KEY).isEmpty());
-      assertTrue(logs.getJsonArray(DO_ACTION_LOGS_KEY).isEmpty());
+      assertTrue(logs.getJsonObject(LOGS).isEmpty());
+      assertTrue(logs.getJsonArray(INVOCATIONS).isEmpty());
     });
   }
 

--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -29,7 +29,8 @@ dependencies {
     implementation(platform("io.knotx:knotx-dependencies:${project.version}"))
 
     api("io.knotx:knotx-server-http-api:${project.version}")
-
+    
+    implementation("io.knotx:knotx-commons:${project.version}")
     implementation(group = "io.vertx", name = "vertx-core")
     implementation(group = "io.vertx", name = "vertx-service-proxy")
     implementation(group = "io.vertx", name = "vertx-rx-java2")

--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -29,7 +29,7 @@ dependencies {
     implementation(platform("io.knotx:knotx-dependencies:${project.version}"))
 
     api("io.knotx:knotx-server-http-api:${project.version}")
-    
+
     implementation("io.knotx:knotx-commons:${project.version}")
     implementation(group = "io.vertx", name = "vertx-core")
     implementation(group = "io.vertx", name = "vertx-service-proxy")

--- a/api/src/main/java/io/knotx/fragments/api/FragmentOperationFailure.java
+++ b/api/src/main/java/io/knotx/fragments/api/FragmentOperationFailure.java
@@ -15,7 +15,7 @@
  */
 package io.knotx.fragments.api;
 
-import io.reactivex.exceptions.CompositeException;
+import io.knotx.commons.error.ExceptionUtils;
 import io.vertx.codegen.annotations.DataObject;
 import io.vertx.core.json.JsonObject;
 import java.util.Collections;
@@ -118,17 +118,9 @@ public class FragmentOperationFailure {
 
   private static List<FragmentOperationError> getExceptionDescriptors(Throwable error) {
     return Stream.of(error)
-        .map(FragmentOperationFailure::flatIfComposite)
+        .map(ExceptionUtils::flatIfComposite)
         .flatMap(List::stream)
         .map(FragmentOperationError::newInstance)
         .collect(Collectors.toList());
-  }
-
-  private static List<Throwable> flatIfComposite(Throwable error) {
-    if (error instanceof CompositeException) {
-      return ((CompositeException) error).getExceptions();
-    } else {
-      return Collections.singletonList(error);
-    }
   }
 }

--- a/task/handler/core/src/main/java/io/knotx/fragments/task/handler/consumer/MetadataConverter.java
+++ b/task/handler/core/src/main/java/io/knotx/fragments/task/handler/consumer/MetadataConverter.java
@@ -81,7 +81,7 @@ class MetadataConverter {
 
   private List<GraphNodeErrorLog> getErrorLogs(Response metadataResponse) {
     return metadataResponse.getErrors().stream()
-        .map(error -> GraphNodeErrorLog.newInstance(error))
+        .map(GraphNodeErrorLog::newInstance)
         .collect(Collectors.toList());
   }
 

--- a/task/handler/core/src/test/java/io/knotx/fragments/task/handler/consumer/EventLogConverterTest.java
+++ b/task/handler/core/src/test/java/io/knotx/fragments/task/handler/consumer/EventLogConverterTest.java
@@ -260,7 +260,7 @@ class EventLogConverterTest {
     return new JsonObject()
         .put("alias", "alias")
         .put("logs", new JsonObject())
-        .put("doActionLogs", new JsonArray());
+        .put("invocations", new JsonArray());
   }
 
 }


### PR DESCRIPTION
## Description
Changes `doActionLogs` occurrences in code to `invocations`. 
Also, changes `doActionLog` in `InvocationLogEntry` to just `log`.
Brings some minor test simplification.

## Motivation and Context
Closes #179

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/Knotx/knotx/blob/master/CONTRIBUTING.md) document.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---
I hereby agree to the terms of the Knot.x Contributor License Agreement.
