### PR TITLE
#173 Provide CopyPayloadKeyActionFactory from knotx-example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,14 @@ All notable changes to `knotx-fragments` will be documented in this file.
 
 ## Unreleased
 List of changes that are finished but not yet released in any final version.
-- [PR-196](https://github.com/Knotx/knotx-fragments/pull/196/files) - Rename `doActionLogs`  in [Actions](https://github.com/Knotx/knotx-fragments/tree/master/action)' log to `invocations`.
-- [PR-195](https://github.com/Knotx/knotx-fragments/pull/195) - Simplifies `ActionProvider`'s constructor.
-- [PR-194](https://github.com/Knotx/knotx-fragments/pull/194) - Generalizes `InMemoryCacheAction` to support different `Cache` implementations. Provides test refactoring.
-- [PR-188](https://github.com/Knotx/knotx-fragments/pull/188) - Exposes nested doActions' (possibly chained) configuration in `OperationMetadata`.
-- [PR-187](https://github.com/Knotx/knotx-fragments/pull/187) - Provides `SingleFragmentOperation` to simplify implementation of RXfied actions.
-- [PR-186](https://github.com/Knotx/knotx-fragments/pull/186) - Provides `FutureFragmentOperation` and `SyncFragmentOperation` to simplify implementation of asynchronous and synchronous actions.
-- [PR-181](https://github.com/Knotx/knotx-fragments/pull/181) - It introduces an error log to `FragmentResult` for handling failures. All `FragmentResult`constructors are deprecated now.
+- [PR-198](https://github.com/Knotx/knotx-fragments/pull/198) - Introduce `CopyPayloadKeyActionFactory` to enable coping inside Fragment's payload.
+- [PR-196](https://github.com/Knotx/knotx-fragments/pull/196) - Rename `doActionLogs`  in [Actions](https://github.com/Knotx/knotx-fragments/tree/master/action)' log to `invocations`.
+- [PR-195](https://github.com/Knotx/knotx-fragments/pull/195) - Simplifie `ActionProvider`'s constructor.
+- [PR-194](https://github.com/Knotx/knotx-fragments/pull/194) - Generalize `InMemoryCacheAction` to support different `Cache` implementations. Provides test refactoring.
+- [PR-188](https://github.com/Knotx/knotx-fragments/pull/188) - Expose nested doActions' (possibly chained) configuration in `OperationMetadata`.
+- [PR-187](https://github.com/Knotx/knotx-fragments/pull/187) - Provide `SingleFragmentOperation` to simplify implementation of RXfied actions.
+- [PR-186](https://github.com/Knotx/knotx-fragments/pull/186) - Provide `FutureFragmentOperation` and `SyncFragmentOperation` to simplify implementation of asynchronous and synchronous actions.
+- [PR-181](https://github.com/Knotx/knotx-fragments/pull/181) - Introduce an error log to `FragmentResult` for handling failures. All `FragmentResult`constructors are deprecated now.
 - [PR-174](https://github.com/Knotx/knotx-fragments/pull/172) - Add node processing errors to the [graph node response log](https://github.com/Knotx/knotx-fragments/blob/master/task/handler/log/api/docs/asciidoc/dataobjects.adoc#graphnoderesponselog).
 - [PR-172](https://github.com/Knotx/knotx-fragments/pull/172) - Add a task node processing exception to event log. Remove unused 'TIMEOUT' node status. Update node unit tests.
 - [PR-170](https://github.com/Knotx/knotx-fragments/pull/170) - Upgrade to Vert.x `3.9.1`, replace deprecated `setHandler` with `onComplete`.

--- a/action/library/README.md
+++ b/action/library/README.md
@@ -213,6 +213,17 @@ When `loglevel` is set to `info`, the action is getting logged:
 - `key` - payload key
 - `value` - payload value
 
+### Copy Payload Key Action
+Copy Payload Key Action copies data inside Fragment's payload. Its configuration looks like:
+```hocon
+factory = copy-payload-key
+config {
+  from = "some.possibly.nested.origin._result"
+  to = "destination.possibly.nested"
+}
+```
+If no data is present in payload under `from` key, the action has no effect on `Fragment`.
+
 ### Payload To Body Action
 Payload To Body Action copies to Fragment body specified payload key value. Its configuration looks like:
 ```hocon

--- a/action/library/src/main/java/io/knotx/fragments/action/library/CopyPayloadKeyActionFactory.java
+++ b/action/library/src/main/java/io/knotx/fragments/action/library/CopyPayloadKeyActionFactory.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2019 Knot.x Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.knotx.fragments.action.library;
+
+import static io.knotx.commons.json.JsonObjectUtil.getObject;
+import static io.knotx.commons.json.JsonObjectUtil.putValue;
+import static io.knotx.commons.validation.ValidationHelper.checkArgument;
+
+import io.knotx.fragments.action.api.Action;
+import io.knotx.fragments.action.api.ActionFactory;
+import io.knotx.fragments.action.api.Cacheable;
+import io.knotx.fragments.action.api.SyncAction;
+import io.knotx.fragments.action.library.exception.ActionConfigurationException;
+import io.knotx.fragments.api.Fragment;
+import io.knotx.fragments.api.FragmentResult;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * Reads data from payload under "from" key and puts it under "to" key. Key names can be defined in
+ * configuration like:
+ * <pre>
+ *   config {
+ *      from = key1
+ *      to = key2
+ *    }
+ * </pre>
+ */
+@Cacheable
+public class CopyPayloadKeyActionFactory implements ActionFactory {
+
+  @Override
+  public String getName() {
+    return "copy-payload-key";
+  }
+
+  @Override
+  public Action create(String alias, JsonObject config, Vertx vertx, Action doAction) {
+    String from = config.getString("from");
+    String to = config.getString("to");
+
+    checkArgument(doAction != null, () -> new ActionConfigurationException(alias,
+        "CopyPayloadKey action does not accept doAction"));
+    checkArgument(StringUtils.isEmpty(from), () -> new ActionConfigurationException(alias,
+        "CopyPayloadKey action requires from property configured"));
+    checkArgument(StringUtils.isEmpty(to), () -> new ActionConfigurationException(alias,
+        "CopyPayloadKey action requires to property configured"));
+
+    return (SyncAction) fragmentContext -> {
+      Fragment fragment = fragmentContext.getFragment();
+      copyInPayload(fragment, from, to);
+      return FragmentResult.success(fragment);
+    };
+  }
+
+  private static void copyInPayload(Fragment fragment, String from, String to) {
+    JsonObject payload = fragment.getPayload();
+    copy(payload, from, to);
+    fragment.mergeInPayload(payload);
+  }
+
+  private static void copy(JsonObject subject, String from, String to) {
+    Object exposedData = getObject(from, subject);
+    if (exposedData != null) {
+      putValue(to, subject, exposedData);
+    }
+  }
+}
+

--- a/action/library/src/main/resources/META-INF/services/io.knotx.fragments.action.api.ActionFactory
+++ b/action/library/src/main/resources/META-INF/services/io.knotx.fragments.action.api.ActionFactory
@@ -17,6 +17,7 @@ io.knotx.fragments.action.library.cb.CircuitBreakerActionFactory
 io.knotx.fragments.action.library.InMemoryCacheActionFactory
 
 # pre-defined actions
+io.knotx.fragments.action.library.CopyPayloadKeyActionFactory
 io.knotx.fragments.action.library.KnotFactory
 io.knotx.fragments.action.library.InlineBodyActionFactory
 io.knotx.fragments.action.library.InlinePayloadActionFactory

--- a/action/library/src/test/java/io/knotx/fragments/action/library/CopyPayloadKeyActionFactoryTest.java
+++ b/action/library/src/test/java/io/knotx/fragments/action/library/CopyPayloadKeyActionFactoryTest.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright (C) 2019 Knot.x Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.knotx.fragments.action.library;
+
+import static io.knotx.commons.json.JsonObjectUtil.getObject;
+import static io.knotx.commons.json.JsonObjectUtil.putValue;
+import static io.knotx.fragments.action.library.TestUtils.ACTION_ALIAS;
+import static io.knotx.fragments.action.library.TestUtils.doActionIdle;
+import static io.knotx.fragments.action.library.TestUtils.someContext;
+import static io.knotx.fragments.action.library.TestUtils.someFragmentWithPayload;
+import static io.knotx.fragments.action.library.TestUtils.verifyActionResult;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import io.knotx.fragments.action.api.Action;
+import io.knotx.fragments.action.library.exception.ActionConfigurationException;
+import io.knotx.fragments.api.FragmentContext;
+import io.vertx.core.json.JsonObject;
+import io.vertx.junit5.Timeout;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(VertxExtension.class)
+@Timeout(value = 5, timeUnit = SECONDS)
+class CopyPayloadKeyActionFactoryTest {
+
+  private static final String FROM = "commonParent.fromSelector.nested._result";
+  private static final String TO = "commonParent.toSelector.nested.something";
+
+  private static final JsonObject CONFIG = new JsonObject()
+      .put("from", FROM)
+      .put("to", TO);
+
+  private static final JsonObject SOME_JSON = new JsonObject()
+      .put("nested", new JsonObject());
+  private static final String SOME_STRING = "test-string";
+
+  private CopyPayloadKeyActionFactory tested;
+
+  @BeforeEach
+  void setUp() {
+    tested = new CopyPayloadKeyActionFactory();
+  }
+
+  @Test
+  @DisplayName("Expect exception when doAction specified")
+  void doActionSpecified() {
+    assertThrows(ActionConfigurationException.class,
+        () -> tested.create(ACTION_ALIAS, CONFIG.copy(), null, doActionIdle()));
+  }
+
+  @Test
+  @DisplayName("Expect exception when config is not valid")
+  void configInvalid() {
+    assertThrows(ActionConfigurationException.class,
+        () -> tested.create(ACTION_ALIAS, new JsonObject(), null, null));
+  }
+
+  @Test
+  @DisplayName("Expect copied json from existing location to empty one")
+  void existingToNewJson(VertxTestContext testContext) {
+    Action action = createWithConfig();
+
+    FragmentContext input = fromPresentToEmpty(SOME_JSON.copy());
+
+    verifyPayloadCopied(testContext, action, input, SOME_JSON);
+  }
+
+  @Test
+  @DisplayName("Expect copied string from existing location to empty one")
+  void existingToNewString(VertxTestContext testContext) {
+    Action action = createWithConfig();
+
+    FragmentContext input = fromPresentToEmpty(SOME_STRING);
+
+    verifyPayloadCopied(testContext, action, input, SOME_STRING);
+  }
+
+  @Test
+  @DisplayName("Expect copied long from existing location to empty one")
+  void existingToNewLong(VertxTestContext testContext) {
+    Action action = createWithConfig();
+
+    FragmentContext input = fromPresentToEmpty(1000L);
+
+    verifyPayloadCopied(testContext, action, input, 1000L);
+  }
+
+  @Test
+  @DisplayName("Expect copied json from existing location to non existing one")
+  void existingToNotExistingJson(VertxTestContext testContext) {
+    Action action = createWithConfig();
+
+    FragmentContext input = fromPresentToMissing(SOME_JSON.copy());
+
+    verifyPayloadCopied(testContext, action, input, SOME_JSON);
+  }
+
+  @Test
+  @DisplayName("Expect payload not copied when value not present")
+  void noValue(VertxTestContext testContext) {
+    Action action = createWithConfig();
+
+    FragmentContext input = empty();
+
+    verifyPayloadEquals(testContext, action, input, new JsonObject());
+  }
+
+  private Action createWithConfig() {
+    return tested.create(ACTION_ALIAS, CONFIG.copy(), null, null);
+  }
+
+  private void verifyPayloadCopied(VertxTestContext testContext, Action action,
+      FragmentContext input, Object value) {
+    verifyActionResult(testContext, action, input, result -> {
+      JsonObject payload = result.result().getFragment().getPayload();
+      assertEquals(value, getObject(FROM, payload));
+      assertEquals(value, getObject(TO, payload));
+    });
+  }
+
+  private void verifyPayloadEquals(VertxTestContext testContext, Action action,
+      FragmentContext input, JsonObject expected) {
+    verifyActionResult(testContext, action, input, result -> {
+      JsonObject payload = result.result().getFragment().getPayload();
+      assertEquals(expected, payload);
+    });
+  }
+
+  private static FragmentContext fromPresentToMissing(Object value) {
+    JsonObject payload = new JsonObject();
+    putValue(FROM, payload, value);
+    return contextWithPayload(payload);
+  }
+
+  private static FragmentContext fromPresentToEmpty(Object value) {
+    JsonObject payload = new JsonObject();
+    putValue(FROM, payload, value);
+    putValue(TO, payload, new JsonObject());
+    return contextWithPayload(payload);
+  }
+
+  private static FragmentContext empty() {
+    return contextWithPayload(new JsonObject());
+  }
+
+  private static FragmentContext contextWithPayload(JsonObject payload) {
+    return someContext(someFragmentWithPayload(payload));
+  }
+
+}


### PR DESCRIPTION
## Description
Brings `CopyPayloadKeyActionFactory` from `knotx-example` repository.
Registers the factory with name `copy-payload-key` on SPI.
Provides unit tests and README update.

## Motivation and Context
Fixes #173.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/Knotx/knotx/blob/master/CONTRIBUTING.md) document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

---
I hereby agree to the terms of the Knot.x Contributor License Agreement.
