### PR TITLE
#209 Provide missing cache action in SPI Manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@ All notable changes to `knotx-fragments` will be documented in this file.
 
 ## Unreleased
 List of changes that are finished but not yet released in any final version.
-                
+- [PR-210](https://github.com/Knotx/knotx-fragments/pull/210) - Fixing [#209](https://github.com/Knotx/knotx-fragments/issues/209): Provide previously missing `CacheActionFactory` via SPI 
+
 ## 2.3.0
 - [PR-203](https://github.com/Knotx/knotx-fragments/pull/203) - Fixing [#197](https://github.com/Knotx/knotx-fragments/issues/197): Invoke actions via ActionInvoker.
 - [PR-201](https://github.com/Knotx/knotx-fragments/pull/201) - Prevent StackOverflowException when evaluating fragment as HTML attributes.

--- a/action/library/src/main/resources/META-INF/services/io.knotx.fragments.action.api.ActionFactory
+++ b/action/library/src/main/resources/META-INF/services/io.knotx.fragments.action.api.ActionFactory
@@ -14,6 +14,9 @@
 
 # behaviours
 io.knotx.fragments.action.library.cb.CircuitBreakerActionFactory
+io.knotx.fragments.action.library.cache.CacheActionFactory
+
+# legacy behaviours
 io.knotx.fragments.action.library.InMemoryCacheActionFactory
 
 # pre-defined actions


### PR DESCRIPTION
## Description
Provides missing action in SPI Manifest

## Motivation and Context
Closes #209

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/Knotx/knotx/blob/master/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---
I hereby agree to the terms of the Knot.x Contributor License Agreement.
