### PR TITLE
Execute tests from all included knotx-stack builds

### DIFF
--- a/action/library/docs/asciidoc/dataobjects.adoc
+++ b/action/library/docs/asciidoc/dataobjects.adoc
@@ -114,9 +114,9 @@ Sets the request body schema to be sent to the endpoint. The body may contain <a
  href="https://github.com/Knotx/knotx-server-http/tree/master/common/placeholders">Knot.x Server
  Common Placeholders</a> referencing ClientRequest, Fragment's configuration or Fragment's
  payload, which will be interpolated if link flag is set.
-
+ <p>
  Please note that request body is sent only in case of using PUT, POST or PATCH HTTP method.
-
+ <p>
  This field is mutually exclusive with link.
 +++
 |[[bodyJson]]`@bodyJson`|`Json object`|+++
@@ -124,20 +124,62 @@ Sets the request body schema to be sent to the endpoint. The body may contain <a
  href="https://github.com/Knotx/knotx-server-http/tree/master/common/placeholders">Knot.x Server
  Common Placeholders</a> referencing ClientRequest, Fragment's configuration or Fragment's
  payload, which will be interpolated if link flag is set.
-
+ <p>
  Please note that request body is sent only in case of using PUT, POST or PATCH HTTP method.
-
+ <p>
  This field is mutually exclusive with link.
 +++
-|[[clearUnmatchedPlaceholdersInBodyJson]]`@clearUnmatchedPlaceholdersInBodyJson`|`Boolean`|-
-|[[clearUnmatchedPlaceholdersInBodyString]]`@clearUnmatchedPlaceholdersInBodyString`|`Boolean`|-
-|[[clearUnmatchedPlaceholdersInPath]]`@clearUnmatchedPlaceholdersInPath`|`Boolean`|-
+|[[clearUnmatchedPlaceholdersInBodyJson]]`@clearUnmatchedPlaceholdersInBodyJson`|`Boolean`|+++
+Configures interpolation of link parameter. When JSON body
+ interpolation is enabled and this flag is set, placeholders not matched to a source will be
+ replaced with an empty string.
+ <p>
+ Please note that absent placeholders that are matched to a source (e.g. {payload.not-existent})
+ will always be replaced with an empty string.
++++
+|[[clearUnmatchedPlaceholdersInBodyString]]`@clearUnmatchedPlaceholdersInBodyString`|`Boolean`|+++
+Configures interpolation of link parameter. When body interpolation is
+ enabled and this flag is set, placeholders not matched to a source will be replaced with an
+ empty string.
+ <p>
+ Please note that absent placeholders that are matched to a source (e.g. {payload.not-existent})
+ will always be replaced with an empty string.
++++
+|[[clearUnmatchedPlaceholdersInPath]]`@clearUnmatchedPlaceholdersInPath`|`Boolean`|+++
+Configures interpolation of link parameter. When path interpolation is
+ enabled and this flag is set, placeholders not matched to a source will be replaced with an
+ empty string.
+ <p>
+ Please note that absent placeholders that are matched to a source (e.g. {payload.not-existent})
+ will always be replaced with an empty string.
++++
 |[[domain]]`@domain`|`String`|+++
 Sets the <code>domain</code> of the external service
 +++
-|[[encodePlaceholdersInBodyJson]]`@encodePlaceholdersInBodyJson`|`Boolean`|-
-|[[encodePlaceholdersInBodyString]]`@encodePlaceholdersInBodyString`|`Boolean`|-
-|[[encodePlaceholdersInPath]]`@encodePlaceholdersInPath`|`Boolean`|-
+|[[encodePlaceholdersInBodyJson]]`@encodePlaceholdersInBodyJson`|`Boolean`|+++
+Configures interpolation of link parameter. When JSON body
+ interpolation is enabled and this flag is set, values of matched placeholders will be encoded
+ before interpolating.
+ <p>
+ For details, see <a href="https://github.com/Knotx/knotx-server-http/tree/master/common/placeholders">Knot.x
+ Server Common Placeholders</a>
++++
+|[[encodePlaceholdersInBodyString]]`@encodePlaceholdersInBodyString`|`Boolean`|+++
+Configures interpolation of link parameter. When body interpolation is
+ enabled and this flag is set, values of matched placeholders will be encoded before
+ interpolating.
+ <p>
+ For details, see <a href="https://github.com/Knotx/knotx-server-http/tree/master/common/placeholders">Knot.x
+ Server Common Placeholders</a>
++++
+|[[encodePlaceholdersInPath]]`@encodePlaceholdersInPath`|`Boolean`|+++
+Configures interpolation of link parameter. When path interpolation is
+ enabled and this flag is set, values of matched placeholders will be encoded before
+ interpolating.
+ <p>
+ For details, see <a href="https://github.com/Knotx/knotx-server-http/tree/master/common/placeholders">Knot.x
+ Server Common Placeholders</a>
++++
 |[[interpolateBody]]`@interpolateBody`|`Boolean`|+++
 Configures interpolation of link parameter. When set, the body will be
  interpolated using <a href="https://github.com/Knotx/knotx-server-http/tree/master/common/placeholders">Knot.x

--- a/api/src/test/java/io/knotx/fragments/api/TestUtils.java
+++ b/api/src/test/java/io/knotx/fragments/api/TestUtils.java
@@ -16,7 +16,6 @@
 
 package io.knotx.fragments.api;
 
-import static io.knotx.fragments.api.FragmentResult.SUCCESS_TRANSITION;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -25,14 +24,13 @@ import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
 import io.vertx.core.json.JsonObject;
 import io.vertx.junit5.VertxTestContext;
-
 import java.util.concurrent.TimeUnit;
 
 public final class TestUtils {
 
   static final Fragment FRAGMENT = new Fragment("", new JsonObject(), "");
   static final FragmentContext FRAGMENT_CONTEXT = new FragmentContext(FRAGMENT, new ClientRequest());
-  static final FragmentResult FRAGMENT_RESULT = new FragmentResult(FRAGMENT, SUCCESS_TRANSITION);
+  static final FragmentResult FRAGMENT_RESULT = FragmentResult.success(FRAGMENT);
 
   private TestUtils() {
     // utility class

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## Description
Add support for running tests for each composite-build modules tests. Apply plugin `composite-build-support` (renamed `publish-all-composite`).

## Motivation and Context
https://github.com/Knotx/knotx-stack/issues/57

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/Knotx/knotx/blob/master/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---
I hereby agree to the terms of the Knot.x Contributor License Agreement.